### PR TITLE
Updated get_dependencies macro to include all nodes (even models/sources with no parents)

### DIFF
--- a/macros/get_dependencies.sql
+++ b/macros/get_dependencies.sql
@@ -57,7 +57,7 @@
     ),
 
     -- recursive CTE
-    -- one record for every root node and each of its downstream children (including itself)
+    -- one record for every node and each of its downstream children (including itself)
     all_relationships as (
 
         -- anchor 
@@ -67,7 +67,7 @@
             0 as distance,
             array_construct(child) as path {# snowflake-specific, but helpful for troubleshooting right now #}
         from direct_relationships
-        where direct_parent is null
+        -- where direct_parent is null {# optional lever to change filtering of anchor clause to only include root nodes #}
 
         union all
 

--- a/models/marts/fct_model_8.sql
+++ b/models/marts/fct_model_8.sql
@@ -1,0 +1,2 @@
+-- a model with no upstream parent nodes
+-- aka a model that is not using the source or ref function

--- a/models/staging/source.yml
+++ b/models/staging/source.yml
@@ -8,3 +8,4 @@ sources:
       - name: table_1
       - name: table_2
       - name: table_3
+      - name: table_4


### PR DESCRIPTION
- currently the `get_dependencies` macro just outputs the SQL, which you can copy and execute in snowflake
- updated the `get_dependencies` to only output paths between nodes and their children, including models/sources with no dependencies
   - outputted result: [result3.csv](https://github.com/dbt-labs/pro-serv-dag-auditing/files/7841458/result3.csv)
- fixed the loop.last logic to (hopefully!) account for all cases, let me know if you think there's a cleaner way to do this
-  added a source with nothing downstream to the DAG for testing
- added a model with nothing upstream to the DAG for testing
---
next steps:
   - fix whitespace
   - determine if `direct_parent_type` is still a useful field, and update macro accordingly 
--- 
future ideas:
   - pull out graph searching to be used in other parts of the audit
   - rename this macro because dependencies is hard to spell :)
   - consider also including exposures? 
