### PR TITLE
Changed "description" field to a boolean

### DIFF
--- a/macros/is_not_empty_string.sql
+++ b/macros/is_not_empty_string.sql
@@ -1,0 +1,9 @@
+{% macro is_not_empty_string(str) %}
+
+    {% if str %}
+    {{ true }}
+    {% else %}
+    {{ false }}
+    {% endif %}
+
+{% endmacro %}

--- a/macros/unpack/get_exposures.sql
+++ b/macros/unpack/get_exposures.sql
@@ -11,7 +11,7 @@
             '{{ node.unique_id }}' as unique_id
             , '{{ node.name }}' as node_name
             , '{{ node.resource_type }}' as resource_type
-            , '{{ node.description }}' as description
+            , '{{ is_not_empty_string(node.description) }}'::boolean as is_described
             , '{{ node.type }}' as exposure_type
             , '{{ node.maturity}}' as maturity
             , '{{ node.package_name }}' as package_name

--- a/macros/unpack/get_metrics.sql
+++ b/macros/unpack/get_metrics.sql
@@ -11,7 +11,7 @@
             '{{ node.unique_id }}' as unique_id
             , '{{ node.name }}' as node_name
             , '{{ node.resource_type }}' as resource_type
-            , '{{ node.description }}' as description
+            , '{{ is_not_empty_string(node.description) }}'::boolean as is_described
             , '{{ node.type }}' as metric_type
             , '{{ node.model.identifier }}' as model
             , '{{ node.label }}' as label

--- a/macros/unpack/get_sources.sql
+++ b/macros/unpack/get_sources.sql
@@ -13,8 +13,8 @@
             , '{{ node.alias }}' as alias
             , '{{ node.resource_type }}' as resource_type
             , '{{ node.source_name }}' as source_name
-            , '{{ node.source_description }}' as source_description
-            , '{{ node.description }}' as description
+            , '{{ is_not_empty_string(node.source_description) }}'::boolean as is_source_described
+            , '{{ is_not_empty_string(node.description) }}'::boolean as is_described
             , '{{ node.config.enabled }}'::boolean as is_enabled
             , '{{ node.loaded_at_field}}' as loaded_at_field
             , '{{ node.database }}' as database

--- a/models/staging/source.yml
+++ b/models/staging/source.yml
@@ -6,6 +6,7 @@ sources:
     database: real_database
     tables:
       - name: table_1
+        description: this is table 1.
       - name: table_2
       - name: table_3
       - name: table_4


### PR DESCRIPTION
A potential fix for #9.

I updated the `description` field to be a boolean: `is_described` which is `true` when a node has a non-empty description field and `false` otherwise. I can't think of a use-case where we would care about the contents of the description, but open to feedback!

Note: This would conflict with the work on @b-per's PR #11. 