### PR TITLE
Make the lineage take in account snapshots

### DIFF
--- a/models/audit/dag/stg_direct_relationships.sql
+++ b/models/audit/dag/stg_direct_relationships.sql
@@ -13,7 +13,7 @@ direct_model_relationships as (
         resource_type,
         direct_parent_id
     from {{ ref('base__node_relationships')}}
-    where resource_type = 'model'
+    where resource_type in ('model','snapshot')
     -- and package_name != 'pro-serv-dag-auditing'
 ),
 


### PR DESCRIPTION
Small fix to take snapshots into account in the lineage.

Without selecting the `resource_type` `snapshot`, the table `fct_root_models` was listing models that were referencing snapshots.