### PR TITLE
feature/model_fanout

### DIFF
--- a/models/audit/dag/dag.yml
+++ b/models/audit/dag/dag.yml
@@ -31,3 +31,7 @@ models:
     description: "This table shows each parent/child reltionship where a model has a reference to both a model and a source."
     tests:
       - is_empty
+  - name: fct_model_fanout
+    description: "This table shows all parents with more direct "leaf" children than the threshold for fanout (determined by variable models_fanout_threshold, default 3)"
+    tests:
+      - is_empty

--- a/models/audit/dag/fct_model_fanout.sql
+++ b/models/audit/dag/fct_model_fanout.sql
@@ -1,0 +1,31 @@
+with all_dag_relationships as (
+    select  
+        *
+    from {{ ref('int_all_dag_relationships') }}
+),
+
+-- find all models without children
+models_without_children as (
+    select
+        parent
+    from all_dag_relationships
+    where parent_type = 'model'
+    group by 1
+    having max(distance) = 0
+),
+
+-- all parents with more direct children than the threshold for fanout (determined by variable models_fanout_threshold, default 3)
+    -- Note: only counts "leaf children" - direct chilren that are models AND are child-less (are at the right-most-point in the DAG)
+model_fanout as (
+    select 
+        all_dag_relationships.parent,
+        count(*) as num_of_leaf_children
+    from all_dag_relationships
+    inner join models_without_children
+        on all_dag_relationships.child = models_without_children.parent
+    where all_dag_relationships.distance = 1 and all_dag_relationships.child_type = 'model'
+    group by 1
+    having count(*) >= {{ var('models_fanout_threshold', 3) }}
+)
+
+select * from model_fanout

--- a/models/audit/dag/stg_direct_relationships.sql
+++ b/models/audit/dag/stg_direct_relationships.sql
@@ -2,6 +2,7 @@
 -- TO DO: exclude models that are part of the audit package
     -- can use package_name attribute in final version
 -- TO DO: fix whitespace
+-- TO DO: determine if we want to include exposures?
 
 -- one record for each node in the DAG (models and sources) and its direct parent
 with 


### PR DESCRIPTION
Created `fct_model_fanout` to check for parents with more direct "leaf" children than the threshold for fanout (determined by variable `models_fanout_threshold`, default 3).

<img width="774" alt="Screen Shot 2022-02-14 at 11 04 07 AM" src="https://user-images.githubusercontent.com/53586774/153900245-37bcf16a-d4f3-4200-b39b-3acac3ed1795.png">

I wanted to create one row per instance of fanout, which is why I decided to return the `parent` and the `num_of_leaf_children`. Do you think this gives enough information? Or do we need to also return the list of children nodes?