### PR TITLE
Fix/Updated select_from_values macro to handle empty values list

### DIFF
--- a/macros/select_from_values.sql
+++ b/macros/select_from_values.sql
@@ -11,6 +11,7 @@
         )
         {%- endset %}
 
+        -- Creates a one-record table with NULL for every column. Then, filters out the NULL records so the final table is empty.
         {{ return(adapter.dispatch('select_from_values')([null_values], column_names) ~ 'where ' ~ column_names[0] ~ ' is not null') }}
 
     {% endif %}


### PR DESCRIPTION
Addresses issue #35 - updated `select_from_values` macro to handle empty values list when a DAG has no exposures, metrics, etc.

