### PR TITLE
remove and rename profiles

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -6,9 +6,6 @@ name: 'dbt_project_evaluator'
 version: '1.0.0'
 config-version: 2
 
-# This setting configures which "profile" dbt uses for this project.
-profile: 'dbt-learn'
-
 # These configurations specify where dbt should look for different types of files.
 # The `source-paths` config, for example, states that models in this project can be
 # found in the "models/" directory. You probably won't need to change these!

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -7,7 +7,7 @@ version: '1.0.0'
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project.
-profile: 'dbt-learn'
+profile: 'integration_tests'
 
 # These configurations specify where dbt should look for different types of files.
 # The `source-paths` config, for example, states that models in this project can be


### PR DESCRIPTION
This PR removes the profile name from the main package to ensure it can be imported, and updates the profile in the `integration_tests` folder to be called `integration_tests`

[related slack thread](https://dbt-labs.slack.com/archives/C02TRN1757B/p1648137944565429?thread_ts=1648131839.925969&cid=C02TRN1757B)