### PR TITLE
Remove duplicate section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,40 +639,6 @@ This file should be moved closest to the subdirectory `intermediate`:
             ├── int_model_4.sql
 ```
 
-## Structure
-### Model Naming Conventions
-#### Model
-
-`fct_model_naming_conventions` ([source](models/marts/structure/fct_model_naming_conventions.sql)) shows all cases where a model does NOT have the appropriate prefix.
-
-#### Reason to Flag
-
-Without appropriate naming conventions, a user querying the data warehouse might incorrectly assume the model type of a given relation. In order to explicitly name
-the model type in the data warehouse, we recommend appropriately prefixing your models in dbt.
-
-| Model Type   | Appropriate Prefixes |
-| ------------ | -------------------- |
-| Staging      | `stg_`               |
-| Intermediate | `int_`               |
-| Marts        | `fct_` or `dim_`     |
-| Other        | `rpt_`               |
-
-#### How to Remediate
-
-For each model flagged, ensure the model type is defined and the model name is prefixed appropriately.
-
-#### Example
-
-Consider `model_8` which is nested in the `marts` subdirectory:
-```
-├── dbt_project.yml
-└── models
-    ├── marts
-        └── model_8.sql
-```
-
-This model should be renamed to either `fct_model_8` or `dim_model_8`.
-
 ### Source Directories
 #### Model
 


### PR DESCRIPTION
The Structure - > Model Naming Conventions section is duplicated

This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->


## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md