### PR TITLE
Add support for Databricks/Spark

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -14,6 +14,10 @@ clean-targets:         # directories to be removed by `dbt clean`
   - "target"
   - "dbt_packages"
 
+dispatch:
+  - macro_namespace: dbt_utils
+    search_order: ['dbt_project_evaluator', 'spark_utils', 'dbt_utils']
+
 models:
   dbt_project_evaluator:
     marts:
@@ -22,7 +26,7 @@ models:
           +materialized: table   
         int_direct_relationships:
           # required for BigQuery and Redshift for performance/memory reasons
-          +materialized: "{{ 'table' if target.type in ['bigquery', 'redshift'] else 'view' }}"
+          +materialized: "{{ 'table' if target.type in ['bigquery', 'redshift', 'databricks'] else 'view' }}"
       dag:
         +materialized: table
     staging:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -24,6 +24,10 @@ clean-targets:         # directories to be removed by `dbt clean`
   - "target"
   - "dbt_packages"
 
+dispatch:
+  - macro_namespace: dbt_utils
+    search_order: ['dbt_project_evaluator', 'spark_utils', 'dbt_utils']
+
 models:
   dbt_project_evaluator_integration_tests:
     # materialize as ephemeral to prevent the fake models from executing, but keep them enabled

--- a/integration_tests/models/staging/source_1/source.yml
+++ b/integration_tests/models/staging/source_1/source.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: source_1
     schema: real_schema
-    database: real_database
+    # database: real_database
     tables:
       - name: table_1
         description: this is table 1.
@@ -13,6 +13,6 @@ sources:
 
   - name: source_2
     schema: real_schema_2
-    database: real_database
+    # database: real_database
     tables:
       - name: table_3

--- a/integration_tests/seeds/dag/dag_seeds.yml
+++ b/integration_tests/seeds/dag/dag_seeds.yml
@@ -2,27 +2,18 @@ version: 2
 
 seeds:
   - name: test_fct_multiple_sources_joined
-    config:
-      column_types:
-        CHILD: varchar
-        SOURCE_PARENTS: varchar
     tests:
       - dbt_utils.equality:
+          name: equality_fct_multiple_sources_joined
           compare_model: ref('fct_multiple_sources_joined')
           compare_columns:
             - child
             - source_parents
 
   - name: test_fct_direct_join_to_source
-    config:
-      column_types:
-        PARENT: varchar
-        PARENT_RESOURCE_TYPE: varchar
-        CHILD: varchar
-        CHILD_RESOURCE_TYPE: varchar
-        DISTANCE: int
     tests:
       - dbt_utils.equality:
+          name: equality_fct_direct_join_to_source
           compare_model: ref('fct_direct_join_to_source')
           compare_columns:
             - parent
@@ -34,44 +25,35 @@ seeds:
   - name: test_fct_root_models
     tests:
       - dbt_utils.equality:
+          name: equality_fct_root_models
           compare_model: ref('fct_root_models')
 
   - name: test_fct_unused_sources
     tests:
       - dbt_utils.equality:
+          name: equality_fct_unused_sources
           compare_model: ref('fct_unused_sources')
 
   - name: test_fct_source_fanout
-    config:
-      column_types:
-        PARENT: varchar
-        MODEL_CHILDREN: varchar
     tests:
       - dbt_utils.equality:
+          name: equality_fct_source_fanout
           compare_model: ref('fct_source_fanout')
           compare_columns:
             - parent
             - model_children
   - name: test_fct_model_fanout
-    config:
-      column_types:
-        PARENT: varchar
-        LEAF_CHILDREN: varchar
     tests:
       - dbt_utils.equality:
+          name: equality_fct_model_fanout
           compare_model: ref('fct_model_fanout')
           compare_columns:
             - parent
             - leaf_children
   - name: test_fct_staging_dependent_on_staging
-    config:
-      column_types:
-        PARENT: varchar
-        PARENT_MODEL_TYPE: varchar
-        CHILD: varchar
-        CHILD_MODEL_TYPE: varchar
     tests:
       - dbt_utils.equality:
+          name: equality_fct_staging_dependent_on_staging
           compare_model: ref('fct_staging_dependent_on_staging')
           compare_columns:
             - parent
@@ -79,14 +61,9 @@ seeds:
             - child
             - child_model_type
   - name: test_fct_rejoining_of_upstream_concepts
-    config:
-      column_types:
-        PARENT: varchar
-        CHILD: varchar
-        PARENT_AND_CHILD: varchar
-        IS_LOOP_INDEPENDENT: boolean
     tests:
       - dbt_utils.equality:
+          name: equality_fct_rejoining_of_upstream_concepts
           compare_model: ref('fct_rejoining_of_upstream_concepts')
           compare_columns:
             - parent

--- a/integration_tests/seeds/docs/docs_seeds.yml
+++ b/integration_tests/seeds/docs/docs_seeds.yml
@@ -7,19 +7,18 @@ seeds:
         - docs
     tests:
       - dbt_utils.equality:
+          name: equality_fct_undocumented_models
           compare_model: ref('fct_undocumented_models')
 
   - name: test_fct_documentation_coverage
     config:
       column_types:
-        total_models: integer
-        documented_models: integer
-        documentation_coverage_pct: float
         marts_documentation_coverage_pct: float
       tags:
         - docs
     tests:
       - dbt_utils.equality:
+          name: equality_fct_documentation_coverage
           compare_model: ref('fct_documentation_coverage')
           compare_columns:
             - total_models

--- a/integration_tests/seeds/structure/structure_seeds.yml
+++ b/integration_tests/seeds/structure/structure_seeds.yml
@@ -2,53 +2,36 @@ version: 2
 
 seeds:
   - name: test_fct_model_directories
-    config:
-      column_types:
-        RESOURCE_NAME: varchar
-        CURRENT_FILE_PATH: varchar
-        CHANGE_FILE_PATH_TO: varchar
     tests:
       - dbt_utils.equality:
+          name: equality_fct_model_directories
           compare_model: ref('fct_model_directories')
           compare_columns:
             - resource_name
             - current_file_path
             - change_file_path_to
   - name: test_fct_model_naming_conventions
-    config:
-      column_types:
-        RESOURCE_NAME: varchar
-        MODEL_TYPE: varchar
-        APPROPRIATE_PREFIXES: varchar
     tests:
       - dbt_utils.equality:
+          name: equality_fct_model_naming_conventions
           compare_model: ref('fct_model_naming_conventions')
           compare_columns:
             - resource_name
             - model_type
             - appropriate_prefixes
   - name: test_fct_source_directories
-    config:
-      column_types:
-        RESOURCE_NAME: varchar
-        CURRENT_FILE_PATH: varchar
-        CHANGE_FILE_PATH_TO: varchar
     tests:
       - dbt_utils.equality:
+          name: equality_fct_source_directories
           compare_model: ref('fct_source_directories')
           compare_columns:
             - resource_name
             - current_file_path
             - change_file_path_to
   - name: test_fct_test_directories
-    config:
-      column_types:
-        TEST_NAME: varchar
-        MODEL_NAME: varchar
-        CURRENT_TEST_DIRECTORY: varchar
-        CHANGE_TEST_DIRECTORY_TO: varchar
     tests:
       - dbt_utils.equality:
+          name: equality_fct_test_directories
           compare_model: ref('fct_test_directories')
           compare_columns:
             - test_name

--- a/integration_tests/seeds/tests/tests_seeds.yml
+++ b/integration_tests/seeds/tests/tests_seeds.yml
@@ -4,19 +4,16 @@ seeds:
   - name: test_fct_missing_primary_key_tests
     tests:
       - dbt_utils.equality:
+          name: equality_fct_missing_primary_key_tests
           compare_model: ref('fct_missing_primary_key_tests')
 
   - name: test_fct_test_coverage
     config:
       column_types:
-        total_models: decimal
-        total_tests: decimal
-        tested_models: decimal
-        test_coverage_pct: float
-        test_to_model_ratio: float
         marts_test_coverage_pct: float
     tests:
       - dbt_utils.equality:
+          name: equality_fct_test_coverage
           compare_model: ref('fct_test_coverage')
           compare_columns:
             - total_models

--- a/macros/array_append.sql
+++ b/macros/array_append.sql
@@ -14,3 +14,7 @@
 {% macro redshift__array_append(array, new_element) -%}
     array_concat({{ array }}, {{ dbt_project_evaluator.create_array([new_element]) }})
 {%- endmacro %}
+
+{% macro spark__array_append(array, new_element) -%}
+    concat({{ array }}, {{ dbt_project_evaluator.create_array([new_element]) }})
+{%- endmacro %}

--- a/macros/create_array.sql
+++ b/macros/create_array.sql
@@ -18,3 +18,7 @@
 {% macro bigquery__array(inputs) -%}
     [ {{ inputs|join(' , ') }} ]
 {%- endmacro %}
+
+{% macro spark__array(inputs) -%}
+    array( {{ inputs|join(' , ') }} )
+{%- endmacro %}

--- a/macros/recursive_dag.sql
+++ b/macros/recursive_dag.sql
@@ -179,3 +179,8 @@ with direct_relationships as (
 )
 
 {% endmacro %}
+
+
+{% macro spark__recursive_dag() %}
+    {{ return(bigquery__recursive_dag()) }}
+{% endmacro %}

--- a/macros/spark_shim.sql
+++ b/macros/spark_shim.sql
@@ -1,0 +1,20 @@
+{% macro spark__listagg(measure, delimiter_text, order_by_clause, limit_num) -%}
+
+    {# 
+        This is not the full support for listagg on databricks but it allows tests to pass/fail for this package
+    #}
+
+    {% if limit_num -%}
+        {%- do exceptions.raise_compiler_error("listagg on databricks doesn't support limit_num") -%}
+    {%- endif %}
+    array_join(
+        sort_array(
+            array_agg(
+                {{ measure }}
+                )
+        )
+        ,
+        {{ delimiter_text }}
+    )
+
+{%- endmacro %}

--- a/models/marts/dag/fct_direct_join_to_source.sql
+++ b/models/marts/dag/fct_direct_join_to_source.sql
@@ -10,12 +10,17 @@ with direct_model_relationships as (
 
 model_and_source_joined as (
     select
-        child
+        child,
+        case 
+            when (
+                sum(case when parent_resource_type = 'model' then 1 else 0 end) > 0 
+                and sum(case when parent_resource_type = 'source' then 1 else 0 end) > 0
+            ) 
+            then true
+            else false 
+        end as keep_row 
     from direct_model_relationships
     group by 1
-    having 
-        sum(case when parent_resource_type = 'model' then 1 else 0 end) > 0 
-        and sum(case when parent_resource_type = 'source' then 1 else 0 end) > 0
 ),
 
 final as (
@@ -23,7 +28,8 @@ final as (
         direct_model_relationships.*
     from direct_model_relationships
     inner join model_and_source_joined
-    on direct_model_relationships.child = model_and_source_joined.child
+        on direct_model_relationships.child = model_and_source_joined.child
+    where model_and_source_joined.keep_row
     order by direct_model_relationships.child
 )
 

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,5 @@
 packages:
   - package: dbt-labs/dbt_utils
     version: 0.8.5
+  - package: dbt-labs/spark_utils
+    version: 0.3.0


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Description & motivation
This PR delivers initial support for databricks/spark.
Noteworthy:
- the package now loads the external `spark_utils` package
- a few macros were created directly in this package but could move to `spark_utils` (e.g. the array ones)
- limited support for `listagg` was added for databricks. It doesn't use all the parameters and should not move to `spark_utils` in its current form but it works for this project
- I removed the column casting for seeds which was creating problems and only kept it for selected columns where BigQuery was raising issues

Keen to get some feedback.

If it is ok to merge, we will also need to:
- update the docs and the project for BQ specific config and wording (e.g. the variable `max_depth_bigquery` which doesn't apply to only BigQuery but also Databricks)
- add to the README which adapters have been tested
- add Databricks to the CI/CD check ?

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->
When running on databricks:
![image](https://user-images.githubusercontent.com/8754100/173540398-b15e61d7-25fc-449c-8556-00e2c61ecb09.png)


## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [x] Snowflake
    - [x] Databricks
- [ ] I have updated the README.md (if applicable)
- [ ] I have added an entry to CHANGELOG.md