### PR TITLE
137 select from values

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -31,10 +31,7 @@ models:
         +materialized: table
     staging:
       graph:
-        stg_nodes:
-          +materialized: table
-        stg_node_relationships:
-          +materialized: table
+        +materialized: table
       variables:
         stg_naming_convention_folders:
           # required for Redshift because listagg runs only on tables

--- a/macros/unpack/get_exposures.sql
+++ b/macros/unpack/get_exposures.sql
@@ -8,6 +8,21 @@
     {% set nodes_list = graph.exposures.values() %}
     {% set values = [] %}
 
+    {% set values0 %}
+
+        cast(null as {{ dbt_utils.type_string() }}),
+        cast(null as {{ dbt_utils.type_string() }}),
+        cast(null as {{ dbt_utils.type_string() }}),
+        cast(null as {{ dbt_utils.type_string() }}),
+        cast(null as boolean),
+        cast(null as {{ dbt_utils.type_string() }}),
+        cast(null as {{ dbt_utils.type_string() }}),
+        cast(null as {{ dbt_utils.type_string() }}),
+        cast(null as {{ dbt_utils.type_string() }})
+
+    {% endset %}
+    {% do values.append(values0) %}
+
     {% for node in nodes_list %}
 
       {% set values_line %}
@@ -41,7 +56,8 @@
               'maturity', 
               'package_name', 
               'url'
-            ]
+            ],
+           where_condition='unique_id is not null'
          )
     ) }}
 

--- a/macros/unpack/get_metrics.sql
+++ b/macros/unpack/get_metrics.sql
@@ -8,6 +8,25 @@
     {% set nodes_list = graph.metrics.values() %}
     {% set values = [] %}
 
+    {% set values0 %}
+
+            cast(null as {{ dbt_utils.type_string() }}),
+            cast(null as {{ dbt_utils.type_string() }}),
+            cast(null as {{ dbt_utils.type_string() }}),
+            cast(null as {{ dbt_utils.type_string() }}),
+            cast(null as boolean),
+            cast(null as {{ dbt_utils.type_string() }}),
+            cast(null as {{ dbt_utils.type_string() }}),
+            cast(null as {{ dbt_utils.type_string() }}),
+            cast(null as {{ dbt_utils.type_string() }}),
+            cast(null as {{ dbt_utils.type_string() }}),
+            cast(null as {{ dbt_utils.type_string() }}),
+            cast(null as {{ dbt_utils.type_string() }}),
+            cast(null as {{ dbt_utils.type_string() }})
+
+    {% endset %}
+    {% do values.append(values0) %}
+
     {% for node in nodes_list %}
 
           {% set values_line %}
@@ -55,7 +74,8 @@
               'package_name',
               'dimensions',
               'filters'
-            ]
+            ],
+            where_condition='unique_id is not null'
          )
     ) }}
 

--- a/macros/unpack/get_nodes.sql
+++ b/macros/unpack/get_nodes.sql
@@ -8,6 +8,26 @@
     {% set nodes_list = graph.nodes.values() %}
     {% set values = [] %}
 
+    {% set values0 %}
+
+              cast(null as {{ dbt_utils.type_string() }}),
+              cast(null as {{ dbt_utils.type_string() }}),
+              cast(null as {{ dbt_utils.type_string() }}),
+              cast(null as {{ dbt_utils.type_string() }}),
+              cast(null as boolean),
+              cast(null as {{ dbt_utils.type_string() }}),
+              cast(null as {{ dbt_utils.type_string() }}),
+              cast(null as {{ dbt_utils.type_string() }}),
+              cast(null as {{ dbt_utils.type_string() }}),
+              cast(null as {{ dbt_utils.type_string() }}),
+              cast(null as {{ dbt_utils.type_string() }}),
+              cast(null as boolean),
+              cast(null as {{ dbt_utils.type_string() }})
+
+    {% endset %}
+    {% do values.append(values0) %}
+
+
     {% for node in nodes_list %}
 
           {% set values_line %}
@@ -49,7 +69,8 @@
               'alias',
               'is_described',
               'column_name'
-            ]
+            ],
+            where_condition='unique_id is not null'
          )
     ) }}
 

--- a/macros/unpack/get_relationships.sql
+++ b/macros/unpack/get_relationships.sql
@@ -18,6 +18,14 @@
         
         {% set values = [] %}
 
+        {% set values0 %}
+
+            cast(null as {{ dbt_utils.type_string() }}),
+            cast(null as {{ dbt_utils.type_string() }})
+
+        {% endset %}
+        {% do values.append(values0) %}
+
         {%- for node in nodes_list -%}
 
             {%- if node.depends_on.nodes|length == 0 -%}
@@ -27,7 +35,7 @@
                 {% endset %}
                 {% do values.append(values_line) %}
 
-            {%- else -%}       
+            {%- else -%}
 
                 {%- for parent in node.depends_on.nodes -%}
 
@@ -48,7 +56,8 @@
             column_names = [
                 'resource_id',
                 'direct_parent_id'
-            ]
+            ],
+            where_condition='resource_id is not null'
          )
     ) }}
 

--- a/macros/unpack/get_sources.sql
+++ b/macros/unpack/get_sources.sql
@@ -8,6 +8,27 @@
     {% set nodes_list = graph.sources.values() %}
     {% set values = [] %}
 
+    {% set values0 %}
+
+              cast(null as {{ dbt_utils.type_string() }}),
+              cast(null as {{ dbt_utils.type_string() }}),
+              cast(null as {{ dbt_utils.type_string() }}),
+              cast(null as {{ dbt_utils.type_string() }}),
+              cast(null as {{ dbt_utils.type_string() }}),
+              cast(null as {{ dbt_utils.type_string() }}),
+              cast(null as boolean),
+              cast(null as boolean),
+              cast(null as boolean),
+              cast(null as {{ dbt_utils.type_string() }}),
+              cast(null as {{ dbt_utils.type_string() }}),
+              cast(null as {{ dbt_utils.type_string() }}),
+              cast(null as {{ dbt_utils.type_string() }}),
+              cast(null as {{ dbt_utils.type_string() }}),
+              cast(null as {{ dbt_utils.type_string() }})
+
+    {% endset %}
+    {% do values.append(values0) %}
+
     {% for node in nodes_list %}
 
          {% set values_line %}
@@ -54,7 +75,8 @@
               'package_name',
               'loader',
               'identifier' 
-            ]
+            ],
+            where_condition='unique_id is not null'
          )
     ) }}
  


### PR DESCRIPTION
This is a:
- [ x ] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->
Closes #137

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->
```
(dbt) vasilii.surov@*** integration_tests % dbt build --full-refresh
23:39:27  Running with dbt=1.1.0
23:39:27  Unable to do partial parsing because a project config has changed
23:39:29  Found 45 models, 48 tests, 0 snapshots, 0 analyses, 466 macros, 0 operations, 16 seed files, 5 sources, 1 exposure, 1 metric
23:39:29  
23:39:31  Concurrency: 20 threads (target='dev')
23:39:31  
23:39:31  1 of 95 START table model ***.stg_exposure_relationships ............. [RUN]
23:39:31  2 of 95 START table model ***.stg_exposures .......................... [RUN]
23:39:31  3 of 95 START table model ***.stg_metric_relationships ............... [RUN]
23:39:31  4 of 95 START table model ***.stg_metrics ............................ [RUN]
23:39:31  5 of 95 START view model ***.stg_naming_convention_folders ........... [RUN]
23:39:31  6 of 95 START view model ***.stg_naming_convention_prefixes .......... [RUN]
23:39:31  7 of 95 START table model ***.stg_node_relationships ................. [RUN]
23:39:31  8 of 95 START table model ***.stg_nodes .............................. [RUN]
23:39:31  9 of 95 START table model ***.stg_sources ............................ [RUN]
23:39:31  10 of 95 START seed file ***.test_fct_direct_join_to_source .......... [RUN]
23:39:31  11 of 95 START seed file ***.test_fct_documentation_coverage ......... [RUN]
23:39:31  12 of 95 START seed file ***.test_fct_missing_primary_key_tests ...... [RUN]
23:39:31  13 of 95 START seed file ***.test_fct_model_directories .............. [RUN]
23:39:31  14 of 95 START seed file ***.test_fct_model_fanout ................... [RUN]
23:39:31  15 of 95 START seed file ***.test_fct_model_naming_conventions ....... [RUN]
23:39:31  16 of 95 START seed file ***.test_fct_multiple_sources_joined ........ [RUN]
23:39:31  17 of 95 START seed file ***.test_fct_rejoining_of_upstream_concepts . [RUN]
23:39:31  18 of 95 START seed file ***.test_fct_root_models .................... [RUN]
23:39:31  19 of 95 START seed file ***.test_fct_source_directories ............. [RUN]
23:39:31  20 of 95 START seed file ***.test_fct_source_fanout .................. [RUN]
23:39:32  6 of 95 OK created view model ***.stg_naming_convention_prefixes ..... [OK in 0.88s]
23:39:32  21 of 95 START seed file ***.test_fct_staging_dependent_on_staging ... [RUN]
23:39:32  5 of 95 OK created view model ***.stg_naming_convention_folders ...... [OK in 0.91s]
23:39:32  22 of 95 START seed file ***.test_fct_test_coverage .................. [RUN]
23:39:34  2 of 95 OK created table model ***.stg_exposures ..................... [CREATE TABLE (1.0 rows, 0 processed) in 2.39s]
23:39:34  23 of 95 START seed file ***.test_fct_test_directories ............... [RUN]
23:39:34  7 of 95 OK created table model ***.stg_node_relationships ............ [CREATE TABLE (143.0 rows, 0 processed) in 2.42s]
23:39:34  24 of 95 START seed file ***.test_fct_undocumented_models ............ [RUN]
23:39:34  3 of 95 OK created table model ***.stg_metric_relationships .......... [CREATE TABLE (1.0 rows, 0 processed) in 2.45s]
23:39:34  25 of 95 START seed file ***.test_fct_unused_sources ................. [RUN]
23:39:34  4 of 95 OK created table model ***.stg_metrics ....................... [CREATE TABLE (1.0 rows, 0 processed) in 2.47s]
23:39:34  1 of 95 OK created table model ***.stg_exposure_relationships ........ [CREATE TABLE (2.0 rows, 0 processed) in 2.47s]
23:39:34  26 of 95 START test unique_stg_model_1_id ...................................... [RUN]
23:39:34  9 of 95 OK created table model ***.stg_sources ....................... [CREATE TABLE (5.0 rows, 0 processed) in 2.48s]
23:39:34  27 of 95 START test not_null_stg_model_2_id .................................... [RUN]
23:39:34  28 of 95 START test unique_stg_model_2_id ...................................... [RUN]
23:39:34  8 of 95 OK created table model ***.stg_nodes ......................... [CREATE TABLE (109.0 rows, 0 processed) in 2.61s]
23:39:34  29 of 95 START test not_null_stg_naming_convention_prefixes_unique_id .......... [RUN]
23:39:34  26 of 95 PASS unique_stg_model_1_id ............................................ [PASS in 0.86s]
23:39:34  30 of 95 START test unique_stg_naming_convention_prefixes_unique_id ............ [RUN]
23:39:34  28 of 95 PASS unique_stg_model_2_id ............................................ [PASS in 0.83s]
23:39:34  31 of 95 START test not_null_stg_naming_convention_folders_folder_name ......... [RUN]
23:39:35  27 of 95 PASS not_null_stg_model_2_id .......................................... [PASS in 0.95s]
23:39:35  32 of 95 START test unique_stg_naming_convention_folders_folder_name ........... [RUN]
23:39:35  29 of 95 PASS not_null_stg_naming_convention_prefixes_unique_id ................ [PASS in 0.88s]
23:39:35  33 of 95 START test not_null_stg_exposures_unique_id ........................... [RUN]
23:39:35  14 of 95 OK loaded seed file ***.test_fct_model_fanout ............... [CREATE 1 in 3.87s]
23:39:35  34 of 95 START test unique_stg_exposures_unique_id ............................. [RUN]
23:39:35  15 of 95 OK loaded seed file ***.test_fct_model_naming_conventions ... [CREATE 4 in 3.91s]
23:39:35  35 of 95 START test not_null_stg_node_relationships_unique_id .................. [RUN]
23:39:35  10 of 95 OK loaded seed file ***.test_fct_direct_join_to_source ...... [CREATE 2 in 3.93s]
23:39:35  19 of 95 OK loaded seed file ***.test_fct_source_directories ......... [CREATE 1 in 3.65s]
23:39:35  36 of 95 START test unique_stg_node_relationships_unique_id .................... [RUN]
23:39:35  37 of 95 START test not_null_stg_metric_relationships_unique_id ................ [RUN]
23:39:35  20 of 95 OK loaded seed file ***.test_fct_source_fanout .............. [CREATE 2 in 3.66s]
23:39:35  18 of 95 OK loaded seed file ***.test_fct_root_models ................ [CREATE 1 in 3.67s]
23:39:35  38 of 95 START test unique_stg_metric_relationships_unique_id .................. [RUN]
23:39:35  39 of 95 START test not_null_stg_metrics_unique_id ............................. [RUN]
23:39:35  13 of 95 OK loaded seed file ***.test_fct_model_directories .......... [CREATE 6 in 4.00s]
23:39:35  11 of 95 OK loaded seed file ***.test_fct_documentation_coverage ..... [CREATE 1 in 4.01s]
23:39:35  40 of 95 START test unique_stg_metrics_unique_id ............................... [RUN]
23:39:35  41 of 95 START test not_null_stg_exposure_relationships_unique_id .............. [RUN]
23:39:35  12 of 95 OK loaded seed file ***.test_fct_missing_primary_key_tests .. [CREATE 11 in 4.04s]
23:39:35  42 of 95 START test unique_stg_exposure_relationships_unique_id ................ [RUN]
23:39:35  16 of 95 OK loaded seed file ***.test_fct_multiple_sources_joined .... [CREATE 1 in 3.80s]
23:39:35  43 of 95 START test not_null_stg_sources_unique_id ............................. [RUN]
23:39:35  17 of 95 OK loaded seed file ***.test_fct_rejoining_of_upstream_concepts  [CREATE 1 in 3.82s]
23:39:35  44 of 95 START test unique_stg_sources_unique_id ............................... [RUN]
23:39:35  30 of 95 PASS unique_stg_naming_convention_prefixes_unique_id .................. [PASS in 0.82s]
23:39:35  45 of 95 START test not_null_stg_nodes_unique_id ............................... [RUN]
23:39:35  31 of 95 PASS not_null_stg_naming_convention_folders_folder_name ............... [PASS in 0.85s]
23:39:35  46 of 95 START test unique_stg_nodes_unique_id ................................. [RUN]
23:39:35  32 of 95 PASS unique_stg_naming_convention_folders_folder_name ................. [PASS in 0.80s]
23:39:35  47 of 95 START test not_null_int_model_4_id .................................... [RUN]
23:39:36  33 of 95 PASS not_null_stg_exposures_unique_id ................................. [PASS in 1.02s]
23:39:36  48 of 95 START test unique_int_model_4_id ...................................... [RUN]
23:39:36  21 of 95 OK loaded seed file ***.test_fct_staging_dependent_on_staging  [CREATE 1 in 3.65s]
23:39:36  49 of 95 START test not_null_stg_model_4_id .................................... [RUN]
23:39:36  22 of 95 OK loaded seed file ***.test_fct_test_coverage .............. [CREATE 1 in 3.67s]
23:39:36  50 of 95 START test unique_stg_model_4_id ...................................... [RUN]
23:39:36  34 of 95 PASS unique_stg_exposures_unique_id ................................... [PASS in 0.85s]
23:39:36  37 of 95 PASS not_null_stg_metric_relationships_unique_id ...................... [PASS in 0.86s]
23:39:36  35 of 95 PASS not_null_stg_node_relationships_unique_id ........................ [PASS in 0.90s]
23:39:36  39 of 95 PASS not_null_stg_metrics_unique_id ................................... [PASS in 0.89s]
23:39:36  41 of 95 PASS not_null_stg_exposure_relationships_unique_id .................... [PASS in 0.87s]
23:39:36  38 of 95 PASS unique_stg_metric_relationships_unique_id ........................ [PASS in 0.93s]
23:39:36  36 of 95 PASS unique_stg_node_relationships_unique_id .......................... [PASS in 1.02s]
23:39:36  42 of 95 PASS unique_stg_exposure_relationships_unique_id ...................... [PASS in 0.93s]
23:39:36  43 of 95 PASS not_null_stg_sources_unique_id ................................... [PASS in 0.90s]
23:39:36  46 of 95 PASS unique_stg_nodes_unique_id ....................................... [PASS in 0.83s]
23:39:36  44 of 95 PASS unique_stg_sources_unique_id ..................................... [PASS in 0.93s]
23:39:36  47 of 95 PASS not_null_int_model_4_id .......................................... [PASS in 0.78s]
23:39:36  45 of 95 PASS not_null_stg_nodes_unique_id ..................................... [PASS in 0.94s]
23:39:36  40 of 95 PASS unique_stg_metrics_unique_id ..................................... [PASS in 1.14s]
23:39:36  51 of 95 START table model ***.int_all_graph_resources ............... [RUN]
23:39:36  49 of 95 PASS not_null_stg_model_4_id .......................................... [PASS in 0.69s]
23:39:36  50 of 95 PASS unique_stg_model_4_id ............................................ [PASS in 0.71s]
23:39:36  48 of 95 PASS unique_int_model_4_id ............................................ [PASS in 0.81s]
23:39:37  24 of 95 OK loaded seed file ***.test_fct_undocumented_models ........ [CREATE 11 in 3.56s]
23:39:38  23 of 95 OK loaded seed file ***.test_fct_test_directories ........... [CREATE 2 in 3.65s]
23:39:38  25 of 95 OK loaded seed file ***.test_fct_unused_sources ............. [CREATE 1 in 3.74s]
23:39:40  51 of 95 OK created table model ***.int_all_graph_resources .......... [CREATE TABLE (85.0 rows, 30.0 KB processed) in 3.41s]
23:39:40  52 of 95 START test not_null_int_all_graph_resources_resource_id ............... [RUN]
23:39:40  53 of 95 START test unique_int_all_graph_resources_resource_id ................. [RUN]
23:39:41  52 of 95 PASS not_null_int_all_graph_resources_resource_id ..................... [PASS in 1.06s]
23:39:41  53 of 95 PASS unique_int_all_graph_resources_resource_id ....................... [PASS in 1.08s]
23:39:41  54 of 95 START view model ***.fct_documentation_coverage ............. [RUN]
23:39:41  55 of 95 START view model ***.fct_model_naming_conventions ........... [RUN]
23:39:41  56 of 95 START view model ***.fct_source_directories ................. [RUN]
23:39:41  57 of 95 START view model ***.fct_undocumented_models ................ [RUN]
23:39:41  58 of 95 START table model ***.int_direct_relationships .............. [RUN]
23:39:41  57 of 95 OK created view model ***.fct_undocumented_models ........... [OK in 0.59s]
23:39:41  59 of 95 START test equality_fct_undocumented_models ........................... [RUN]
23:39:42  55 of 95 OK created view model ***.fct_model_naming_conventions ...... [OK in 0.76s]
23:39:42  60 of 95 START test equality_fct_model_naming_conventions ...................... [RUN]
23:39:42  54 of 95 OK created view model ***.fct_documentation_coverage ........ [OK in 0.85s]
23:39:42  61 of 95 START test equality_fct_documentation_coverage ........................ [RUN]
23:39:42  56 of 95 OK created view model ***.fct_source_directories ............ [OK in 0.97s]
23:39:42  62 of 95 START test equality_fct_source_directories ............................ [RUN]
23:39:43  59 of 95 PASS equality_fct_undocumented_models ................................. [PASS in 1.24s]
23:39:43  62 of 95 PASS equality_fct_source_directories .................................. [PASS in 1.01s]
23:39:43  61 of 95 PASS equality_fct_documentation_coverage .............................. [PASS in 1.24s]
23:39:43  58 of 95 OK created table model ***.int_direct_relationships ......... [CREATE TABLE (106.0 rows, 33.8 KB processed) in 2.14s]
23:39:43  63 of 95 START test not_null_int_direct_relationships_unique_id ................ [RUN]
23:39:43  64 of 95 START test unique_int_direct_relationships_unique_id .................. [RUN]
23:39:43  60 of 95 PASS equality_fct_model_naming_conventions ............................ [PASS in 1.51s]
23:39:44  63 of 95 PASS not_null_int_direct_relationships_unique_id ...................... [PASS in 0.87s]
23:39:44  64 of 95 PASS unique_int_direct_relationships_unique_id ........................ [PASS in 0.94s]
23:39:44  65 of 95 START view model ***.fct_test_directories ................... [RUN]
23:39:44  66 of 95 START view model ***.int_all_dag_relationships .............. [RUN]
23:39:44  67 of 95 START view model ***.int_model_test_summary ................. [RUN]
23:39:45  67 of 95 OK created view model ***.int_model_test_summary ............ [OK in 0.72s]
23:39:45  68 of 95 START test not_null_int_model_test_summary_resource_name .............. [RUN]
23:39:45  69 of 95 START test unique_int_model_test_summary_resource_name ................ [RUN]
23:39:45  65 of 95 OK created view model ***.fct_test_directories .............. [OK in 0.75s]
23:39:45  70 of 95 START test equality_fct_test_directories .............................. [RUN]
23:39:45  66 of 95 OK created view model ***.int_all_dag_relationships ......... [OK in 0.91s]
23:39:45  71 of 95 START test not_null_int_all_dag_relationships_path .................... [RUN]
23:39:46  69 of 95 PASS unique_int_model_test_summary_resource_name ...................... [PASS in 1.12s]
23:39:46  68 of 95 PASS not_null_int_model_test_summary_resource_name .................... [PASS in 1.14s]
23:39:46  72 of 95 START view model ***.fct_missing_primary_key_tests .......... [RUN]
23:39:46  73 of 95 START view model ***.fct_test_coverage ...................... [RUN]
23:39:46  70 of 95 PASS equality_fct_test_directories .................................... [PASS in 1.59s]
23:39:47  73 of 95 OK created view model ***.fct_test_coverage ................. [OK in 0.79s]
23:39:47  72 of 95 OK created view model ***.fct_missing_primary_key_tests ..... [OK in 0.79s]
23:39:47  74 of 95 START test equality_fct_missing_primary_key_tests ..................... [RUN]
23:39:47  75 of 95 START test equality_fct_test_coverage ................................. [RUN]
23:39:47  71 of 95 PASS not_null_int_all_dag_relationships_path .......................... [PASS in 2.26s]
23:39:47  76 of 95 START table model ***.fct_direct_join_to_source ............. [RUN]
23:39:47  77 of 95 START table model ***.fct_marts_or_intermediate_dependent_on_source  [RUN]
23:39:47  78 of 95 START view model ***.fct_model_directories .................. [RUN]
23:39:47  79 of 95 START table model ***.fct_model_fanout ...................... [RUN]
23:39:47  80 of 95 START table model ***.fct_multiple_sources_joined ........... [RUN]
23:39:47  81 of 95 START table model ***.fct_rejoining_of_upstream_concepts .... [RUN]
23:39:47  82 of 95 START table model ***.fct_root_models ....................... [RUN]
23:39:47  83 of 95 START table model ***.fct_source_fanout ..................... [RUN]
23:39:47  84 of 95 START table model ***.fct_staging_dependent_on_marts_or_intermediate  [RUN]
23:39:47  85 of 95 START table model ***.fct_staging_dependent_on_staging ...... [RUN]
23:39:47  86 of 95 START table model ***.fct_unused_sources .................... [RUN]
23:39:48  78 of 95 OK created view model ***.fct_model_directories ............. [OK in 0.89s]
23:39:48  87 of 95 START test equality_fct_model_directories ............................. [RUN]
23:39:48  75 of 95 PASS equality_fct_test_coverage ....................................... [PASS in 1.86s]
23:39:49  74 of 95 PASS equality_fct_missing_primary_key_tests ........................... [PASS in 2.00s]
23:39:50  77 of 95 OK created table model ***.fct_marts_or_intermediate_dependent_on_source  [CREATE TABLE (2.0 rows, 26.7 KB processed) in 2.79s]
23:39:50  84 of 95 OK created table model ***.fct_staging_dependent_on_marts_or_intermediate  [CREATE TABLE (1.0 rows, 26.7 KB processed) in 2.80s]
23:39:50  80 of 95 OK created table model ***.fct_multiple_sources_joined ...... [CREATE TABLE (1.0 rows, 26.6 KB processed) in 2.83s]
23:39:50  88 of 95 START test equality_fct_multiple_sources_joined ....................... [RUN]
23:39:50  83 of 95 OK created table model ***.fct_source_fanout ................ [CREATE TABLE (2.0 rows, 26.6 KB processed) in 2.87s]
23:39:50  89 of 95 START test equality_fct_source_fanout ................................. [RUN]
23:39:50  85 of 95 OK created table model ***.fct_staging_dependent_on_staging . [CREATE TABLE (1.0 rows, 26.7 KB processed) in 3.02s]
23:39:50  90 of 95 START test equality_fct_staging_dependent_on_staging .................. [RUN]
23:39:50  76 of 95 OK created table model ***.fct_direct_join_to_source ........ [CREATE TABLE (2.0 rows, 33.6 KB processed) in 3.28s]
23:39:50  91 of 95 START test equality_fct_direct_join_to_source ......................... [RUN]
23:39:51  88 of 95 PASS equality_fct_multiple_sources_joined ............................. [PASS in 0.92s]
23:39:51  89 of 95 PASS equality_fct_source_fanout ....................................... [PASS in 0.99s]
23:39:51  86 of 95 OK created table model ***.fct_unused_sources ............... [CREATE TABLE (1.0 rows, 26.6 KB processed) in 3.94s]
23:39:51  92 of 95 START test equality_fct_unused_sources ................................ [RUN]
23:39:51  82 of 95 OK created table model ***.fct_root_models .................. [CREATE TABLE (1.0 rows, 26.6 KB processed) in 4.07s]
23:39:51  93 of 95 START test equality_fct_root_models ................................... [RUN]
23:39:51  90 of 95 PASS equality_fct_staging_dependent_on_staging ........................ [PASS in 1.06s]
23:39:51  91 of 95 PASS equality_fct_direct_join_to_source ............................... [PASS in 0.84s]
23:39:52  79 of 95 OK created table model ***.fct_model_fanout ................. [CREATE TABLE (1.0 rows, 26.6 KB processed) in 4.54s]
23:39:52  94 of 95 START test equality_fct_model_fanout .................................. [RUN]
23:39:52  92 of 95 PASS equality_fct_unused_sources ...................................... [PASS in 0.99s]
23:39:52  93 of 95 PASS equality_fct_root_models ......................................... [PASS in 1.11s]
23:39:52  81 of 95 OK created table model ***.fct_rejoining_of_upstream_concepts  [CREATE TABLE (1.0 rows, 26.6 KB processed) in 5.20s]
23:39:52  95 of 95 START test equality_fct_rejoining_of_upstream_concepts ................ [RUN]
23:39:52  94 of 95 PASS equality_fct_model_fanout ........................................ [PASS in 0.84s]
23:39:52  87 of 95 PASS equality_fct_model_directories ................................... [PASS in 4.51s]
23:39:53  95 of 95 PASS equality_fct_rejoining_of_upstream_concepts ...................... [PASS in 1.01s]
23:39:53  
23:39:53  Finished running 12 view models, 19 table models, 48 tests, 16 seeds in 24.19s.
23:39:53  
23:39:53  Completed successfully
23:39:53  
23:39:53  Done. PASS=95 WARN=0 ERROR=0 SKIP=0 TOTAL=95
```

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md