### PR TITLE
✨ Add info about Databricks support

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -70,4 +70,4 @@ vars:
   other_prefixes: ['rpt_']
 
   # -- Warehouse specific variables --
-  max_depth_bigquery: 9
+  max_depth_dag: 9

--- a/macros/recursive_dag.sql
+++ b/macros/recursive_dag.sql
@@ -96,7 +96,7 @@ all_relationships (
 {% macro bigquery__recursive_dag() %}
 
 -- as of Feb 2022 BigQuery doesn't support with recursive in the same way as other DWs
-{% set max_depth = var('max_depth_bigquery',9) %}
+{% set max_depth = var('max_depth_dag',9) %}
 
 with direct_relationships as (
     select  
@@ -182,5 +182,6 @@ with direct_relationships as (
 
 
 {% macro spark__recursive_dag() %}
+-- as of June 2022 databricks SQL doesn't support "with recursive" in the same way as other DWs
     {{ return(bigquery__recursive_dag()) }}
 {% endmacro %}


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes
- [ ] new functionality
- [x] docs update

This is a docs update to mention the supported warehouses and add a setup step for Databricks users.

I have also updated the name of a variable from `max_depth_bigquery` to `max_depth_dag` as it is used for both BQ and Databricks now.