### PR TITLE
Run in CI without exposures or metrics

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -20,3 +20,8 @@ fi
 
 dbt deps --target $1 || exit 1
 dbt build -x --target $1 --full-refresh || exit 1
+
+# test without exposures or metrics
+rm models/marts/exposures.yml
+rm models/marts/metrics.yml
+dbt run -x --target $1 --select +int_direct_relationships +int_all_graph_resources || exit 1


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes
- [ ] new functionality
- [x] an update to the CI flow

This change should also check if the first models run fine when the dbt project of the users doesn't have any exposure or metric. Most of the errors raised so far are due to having no exposure/metric.

It is expected that this check will fail right now 