### PR TITLE
handle projects without certain node types

### DIFF
--- a/macros/select_from_values.sql
+++ b/macros/select_from_values.sql
@@ -1,20 +1,6 @@
 {% macro select_from_values(values,column_names) %}
-
-    {% if values %}
-        {{ return(adapter.dispatch('select_from_values', 'dbt_project_evaluator')(values, column_names)) }}
-    {% else %} -- if values is an empty list, return an empty table
-        {% set null_values -%}
-        
-            {% for column in column_names %}
-            NULL{% if not loop.last %},{% endif %}
-            {% endfor %}
-        
-        {%- endset %}
-
-        -- Creates a one-record table with NULL for every column. Then, filters out the NULL records so the final table is empty.
-        {{ return(adapter.dispatch('select_from_values', 'dbt_project_evaluator')([null_values], column_names) ~ 'where ' ~ column_names[0] ~ ' is not null') }}
-
-    {% endif %}
+    
+    {{ return(adapter.dispatch('select_from_values', 'dbt_project_evaluator')(values, column_names)) }}
 
 {% endmacro %}
 

--- a/macros/unpack/get_exposures.sql
+++ b/macros/unpack/get_exposures.sql
@@ -6,43 +6,61 @@
 
     {% if execute %}
     {% set nodes_list = graph.exposures.values() %}
-    {% set values = [] %}
+      {% if nodes_list | length > 0 %}
+        {% set values = [] %}
 
-    {% for node in nodes_list %}
+        {% for node in nodes_list %}
 
-      {% set values_line %}
+          {% set values_line %}
 
-        '{{ node.unique_id }}',
-        '{{ node.name }}',
-        '{{ node.resource_type }}',
-        '{{ node.original_file_path }}',
-        cast('{{ dbt_project_evaluator.is_not_empty_string(node.description) | trim }}'as boolean),
-        '{{ node.type }}',
-        '{{ node.maturity}}',
-        '{{ node.package_name }}',
-        '{{ node.url }}'
+            '{{ node.unique_id }}',
+            '{{ node.name }}',
+            '{{ node.resource_type }}',
+            '{{ node.original_file_path }}',
+            cast('{{ dbt_project_evaluator.is_not_empty_string(node.description) | trim }}'as boolean),
+            '{{ node.type }}',
+            '{{ node.maturity}}',
+            '{{ node.package_name }}',
+            '{{ node.url }}'
+          
+          {% endset %}
+          {% do values.append(values_line) %}
+
+        {% endfor %}
+
+        {{ return(
+            dbt_project_evaluator.select_from_values(
+                values = values,
+                column_names = [
+                  'unique_id', 
+                  'name', 
+                  'resource_type',
+                  'file_path', 
+                  'is_described', 
+                  'exposure_type', 
+                  'maturity', 
+                  'package_name', 
+                  'url'
+                ]
+            )
+        ) }}
+
+      {% else %}
+
+      select 
+        cast(null as {{ dbt_utils.type_string() }}) as unique_id, 
+        cast(null as {{ dbt_utils.type_string() }}) as name, 
+        cast(null as {{ dbt_utils.type_string() }}) as resource_type,
+        cast(null as {{ dbt_utils.type_string() }}) as file_path, 
+        cast(null as boolean) as is_described, 
+        cast(null as {{ dbt_utils.type_string() }}) as exposure_type, 
+        cast(null as {{ dbt_utils.type_string() }}) as maturity, 
+        cast(null as {{ dbt_utils.type_string() }}) as package_name, 
+        cast(null as {{ dbt_utils.type_string() }}) as url
       
-      {% endset %}
-      {% do values.append(values_line) %}
+      where false
 
-    {% endfor %}
+      {% endif %}
     {% endif %}
-
-    {{ return(
-        dbt_project_evaluator.select_from_values(
-            values = values,
-            column_names = [
-              'unique_id', 
-              'name', 
-              'resource_type',
-              'file_path', 
-              'is_described', 
-              'exposure_type', 
-              'maturity', 
-              'package_name', 
-              'url'
-            ]
-         )
-    ) }}
 
 {% endmacro %}

--- a/macros/unpack/get_metrics.sql
+++ b/macros/unpack/get_metrics.sql
@@ -6,57 +6,79 @@
 
     {% if execute %}
     {% set nodes_list = graph.metrics.values() %}
-    {% set values = [] %}
+      {% if nodes_list | length > 0 %}
+        {% set values = [] %}
 
-    {% for node in nodes_list %}
+        {% for node in nodes_list %}
 
-          {% set values_line %}
+              {% set values_line %}
 
-            '{{ node.unique_id }}',
-            '{{ node.name }}',
-            '{{ node.resource_type }}',
-            '{{ node.original_file_path }}',
-            cast('{{ dbt_project_evaluator.is_not_empty_string(node.description) | trim }}' as boolean),
-            '{{ node.type }}',
-            '{{ node.model.identifier }}',
-            '{{ node.label }}',
-            '{{ node.sql }}',
-            '{{ node.timestamp }}',
-            '{{ node.package_name }}',
-            '{{ node.dimensions|join(' - ') }}',
-            {% if node.filters|length %}
-              {% for filt in node.filters %}
-                '{{ filt.field }}'||'{{ filt.operator }}'||'''{{ filt.value }}'''
-                {% if not loop.last %}|| ' - '{% endif %}
-              {% endfor %}
-            {% else %}
-                ''
-            {% endif %}
-        {% endset %}
-        {% do values.append(values_line) %}
+                '{{ node.unique_id }}',
+                '{{ node.name }}',
+                '{{ node.resource_type }}',
+                '{{ node.original_file_path }}',
+                cast('{{ dbt_project_evaluator.is_not_empty_string(node.description) | trim }}' as boolean),
+                '{{ node.type }}',
+                '{{ node.model.identifier }}',
+                '{{ node.label }}',
+                '{{ node.sql }}',
+                '{{ node.timestamp }}',
+                '{{ node.package_name }}',
+                '{{ node.dimensions|join(' - ') }}',
+                {% if node.filters|length %}
+                  {% for filt in node.filters %}
+                    '{{ filt.field }}'||'{{ filt.operator }}'||'''{{ filt.value }}'''
+                    {% if not loop.last %}|| ' - '{% endif %}
+                  {% endfor %}
+                {% else %}
+                    ''
+                {% endif %}
+            {% endset %}
+            {% do values.append(values_line) %}
 
-    {% endfor %}
+        {% endfor %}
+
+
+        {{ return(
+            dbt_project_evaluator.select_from_values(
+                values = values,
+                column_names = [
+                  'unique_id', 
+                  'name', 
+                  'resource_type', 
+                  'file_path', 
+                  'is_described', 
+                  'metric_type', 
+                  'model',
+                  'label', 
+                  'sql', 
+                  'timestamp', 
+                  'package_name',
+                  'dimensions',
+                  'filters'
+                ]
+            )
+        ) }}
+      {% else %}
+
+        select 
+          cast(null as {{ dbt_utils.type_string() }}) as unique_id, 
+          cast(null as {{ dbt_utils.type_string() }}) as name, 
+          cast(null as {{ dbt_utils.type_string() }}) as resource_type, 
+          cast(null as {{ dbt_utils.type_string() }}) as file_path, 
+          cast(null as boolean) as is_described, 
+          cast(null as {{ dbt_utils.type_string() }}) as metric_type, 
+          cast(null as {{ dbt_utils.type_string() }}) as model,
+          cast(null as {{ dbt_utils.type_string() }}) as label, 
+          cast(null as {{ dbt_utils.type_string() }}) as sql, 
+          cast(null as {{ dbt_utils.type_string() }}) as timestamp, 
+          cast(null as {{ dbt_utils.type_string() }}) as package_name,
+          cast(null as {{ dbt_utils.type_string() }}) as dimensions,
+          cast(null as {{ dbt_utils.type_string() }}) as filters
+
+        where false 
+      {% endif %}
+    
     {% endif %}
-
-    {{ return(
-        dbt_project_evaluator.select_from_values(
-            values = values,
-            column_names = [
-              'unique_id', 
-              'name', 
-              'resource_type', 
-              'file_path', 
-              'is_described', 
-              'metric_type', 
-              'model',
-              'label', 
-              'sql', 
-              'timestamp', 
-              'package_name',
-              'dimensions',
-              'filters'
-            ]
-         )
-    ) }}
 
 {% endmacro %}

--- a/macros/unpack/get_nodes.sql
+++ b/macros/unpack/get_nodes.sql
@@ -6,51 +6,75 @@
 
     {% if execute %}
     {% set nodes_list = graph.nodes.values() %}
-    {% set values = [] %}
+    {% if nodes_list | length > 0 %}
+      
+        {% set values = [] %}
 
-    {% for node in nodes_list %}
+        {% for node in nodes_list %}
 
-          {% set values_line %}
+            {% set values_line %}
 
-              '{{ node.unique_id }}',
-              '{{ node.name }}',
-              '{{ node.resource_type }}',
-              '{{ node.original_file_path }}',
-              cast('{{ node.config.enabled | trim }}' as boolean),
-              '{{ node.config.materialized }}',
-              '{{ node.config.on_schema_change}}',
-              '{{ node.database }}',
-              '{{ node.schema }}',
-              '{{ node.package_name }}',
-              '{{ node.alias }}',
-              cast('{{ dbt_project_evaluator.is_not_empty_string(node.description) | trim }}' as boolean),
-              '{{ "" if not node.column_name else node.column_name }}'
+                '{{ node.unique_id }}',
+                '{{ node.name }}',
+                '{{ node.resource_type }}',
+                '{{ node.original_file_path }}',
+                cast('{{ node.config.enabled | trim }}' as boolean),
+                '{{ node.config.materialized }}',
+                '{{ node.config.on_schema_change}}',
+                '{{ node.database }}',
+                '{{ node.schema }}',
+                '{{ node.package_name }}',
+                '{{ node.alias }}',
+                cast('{{ dbt_project_evaluator.is_not_empty_string(node.description) | trim }}' as boolean),
+                '{{ "" if not node.column_name else node.column_name }}'
 
-        {% endset %}
-        {% do values.append(values_line) %}
+            {% endset %}
+            {% do values.append(values_line) %}
 
-    {% endfor %}
+        {% endfor %}
+
+        {{ return(
+            dbt_project_evaluator.select_from_values(
+                values = values,
+                column_names = [
+                'unique_id',
+                'name',
+                'resource_type',
+                'file_path',
+                'is_enabled',
+                'materialized',
+                'on_schema_change',
+                'database',
+                'schema',
+                'package_name',
+                'alias',
+                'is_described',
+                'column_name'
+                ]
+            )
+        ) }}
+
+    {% else %}
+
+        select 
+            cast(null as {{ dbt_utils.type_string() }}) as unique_id,
+            cast(null as {{ dbt_utils.type_string() }}) as name,
+            cast(null as {{ dbt_utils.type_string() }}) as resource_type,
+            cast(null as {{ dbt_utils.type_string() }}) as file_path,
+            cast(null as boolean) as is_enabled,
+            cast(null as {{ dbt_utils.type_string() }}) as materialized,
+            cast(null as {{ dbt_utils.type_string() }}) as on_schema_change,
+            cast(null as {{ dbt_utils.type_string() }}) as database,
+            cast(null as {{ dbt_utils.type_string() }}) as schema,
+            cast(null as {{ dbt_utils.type_string() }}) as package_name,
+            cast(null as {{ dbt_utils.type_string() }}) as alias,
+            cast(null as boolean) as is_described,
+            cast(null as {{ dbt_utils.type_string() }}) as column_name
+    
+        where false
+    
     {% endif %}
 
-    {{ return(
-        dbt_project_evaluator.select_from_values(
-            values = values,
-            column_names = [
-              'unique_id',
-              'name',
-              'resource_type',
-              'file_path',
-              'is_enabled',
-              'materialized',
-              'on_schema_change',
-              'database',
-              'schema',
-              'package_name',
-              'alias',
-              'is_described',
-              'column_name'
-            ]
-         )
-    ) }}
+    {% endif %}
 
 {% endmacro %}

--- a/macros/unpack/get_relationships.sql
+++ b/macros/unpack/get_relationships.sql
@@ -15,43 +15,54 @@
         {% else %}
             {{ exceptions.raise_compiler_error("node_type needs to be either nodes, exposures or metrics, got " ~ node_type) }}
         {% endif %}
+
+        {% if nodes_list | length > 0 %}
         
-        {% set values = [] %}
+            {% set values = [] %}
 
-        {%- for node in nodes_list -%}
+            {%- for node in nodes_list -%}
 
-            {%- if node.depends_on.nodes|length == 0 -%}
-
-                {% set values_line %}
-                  cast('{{ node.unique_id }}' as {{ dbt_utils.type_string() }}),cast(NULL as {{ dbt_utils.type_string() }})
-                {% endset %}
-                {% do values.append(values_line) %}
-
-            {%- else -%}       
-
-                {%- for parent in node.depends_on.nodes -%}
+                {%- if node.depends_on.nodes|length == 0 -%}
 
                     {% set values_line %}
-                      cast('{{ node.unique_id }}' as {{ dbt_utils.type_string() }}),cast('{{ parent }}' as {{ dbt_utils.type_string() }})
+                    cast('{{ node.unique_id }}' as {{ dbt_utils.type_string() }}),cast(NULL as {{ dbt_utils.type_string() }})
                     {% endset %}
                     {% do values.append(values_line) %}
 
-                {% endfor -%}
+                {%- else -%}       
 
-            {%- endif %}
+                    {%- for parent in node.depends_on.nodes -%}
 
-        {% endfor -%}
+                        {% set values_line %}
+                        cast('{{ node.unique_id }}' as {{ dbt_utils.type_string() }}),cast('{{ parent }}' as {{ dbt_utils.type_string() }})
+                        {% endset %}
+                        {% do values.append(values_line) %}
+
+                    {% endfor -%}
+
+                {%- endif %}
+
+            {% endfor -%}
+        
+        {{ return(
+            dbt_project_evaluator.select_from_values(
+                values = values,
+                column_names = [
+                    'resource_id',
+                    'direct_parent_id'
+                ]
+            )
+        ) }}
     
-    {{ return(
-        dbt_project_evaluator.select_from_values(
-            values = values,
-            column_names = [
-                'resource_id',
-                'direct_parent_id'
-            ]
-         )
-    ) }}
+    {% else %}
 
+        select 
+            cast(null as {{ dbt_utils.type_string() }}) as resource_id,
+            cast(null as {{ dbt_utils.type_string() }}) as direct_parent_id
+
+        where false 
+
+    {% endif %}
     {% endif %}
   
 {% endmacro %}

--- a/macros/unpack/get_sources.sql
+++ b/macros/unpack/get_sources.sql
@@ -7,55 +7,79 @@
     {% if execute %}
     {% set nodes_list = graph.sources.values() %}
     {% set values = [] %}
+    {% if nodes_list | length > 0 %}
 
-    {% for node in nodes_list %}
+        {% for node in nodes_list %}
 
-         {% set values_line %}
-            
-              '{{ node.unique_id }}', 
-              '{{ node.name }}',
-              '{{ node.original_file_path }}',
-              '{{ node.alias }}',
-              '{{ node.resource_type }}',
-              '{{ node.source_name }}',
-              cast('{{ dbt_project_evaluator.is_not_empty_string(node.source_description) | trim }}' as boolean),
-              cast('{{ dbt_project_evaluator.is_not_empty_string(node.description) | trim }}' as boolean),
-              cast('{{ node.config.enabled }}' as boolean),
-              '{{ node.loaded_at_field | replace("'", "_") }}}}',
-              '{{ node.database }}',
-              '{{ node.schema }}',
-              '{{ node.package_name }}',
-              '{{ node.loader }}',
-              '{{ node.identifier }}'
+            {% set values_line %}
+                
+                '{{ node.unique_id }}', 
+                '{{ node.name }}',
+                '{{ node.original_file_path }}',
+                '{{ node.alias }}',
+                '{{ node.resource_type }}',
+                '{{ node.source_name }}',
+                cast('{{ dbt_project_evaluator.is_not_empty_string(node.source_description) | trim }}' as boolean),
+                cast('{{ dbt_project_evaluator.is_not_empty_string(node.description) | trim }}' as boolean),
+                cast('{{ node.config.enabled }}' as boolean),
+                '{{ node.loaded_at_field | replace("'", "_") }}}}',
+                '{{ node.database }}',
+                '{{ node.schema }}',
+                '{{ node.package_name }}',
+                '{{ node.loader }}',
+                '{{ node.identifier }}'
 
-        {% endset %}
-        {% do values.append(values_line) %}
+            {% endset %}
+            {% do values.append(values_line) %}
 
-    {% endfor %}
+        {% endfor %}
+
+
+
+        {{ return(
+            dbt_project_evaluator.select_from_values(
+                values = values,
+                column_names = [
+                'unique_id',
+                'name',
+                'file_path',
+                'alias',
+                'resource_type',
+                'source_name',
+                'is_source_described',
+                'is_described',
+                'is_enabled',
+                'loaded_at_field',
+                'database',
+                'schema',
+                'package_name',
+                'loader',
+                'identifier' 
+                ]
+            )
+        ) }}
+
+    {% else %}
+        select 
+            cast(null as {{ dbt_utils.type_string() }}) as unique_id,
+            cast(null as {{ dbt_utils.type_string() }}) as name,
+            cast(null as {{ dbt_utils.type_string() }}) as file_path,
+            cast(null as {{ dbt_utils.type_string() }}) as alias,
+            cast(null as {{ dbt_utils.type_string() }}) as resource_type,
+            cast(null as {{ dbt_utils.type_string() }}) as source_name,
+            cast(null as boolean) as is_source_described,
+            cast(null as boolean) as is_described,
+            cast(null as boolean) as is_enabled,
+            cast(null as {{ dbt_utils.type_string() }}) as loaded_at_field,
+            cast(null as {{ dbt_utils.type_string() }}) as database,
+            cast(null as {{ dbt_utils.type_string() }}) as schema,
+            cast(null as {{ dbt_utils.type_string() }}) as package_name,
+            cast(null as {{ dbt_utils.type_string() }}) as loader,
+            cast(null as {{ dbt_utils.type_string() }}) as identifier 
+
+
     {% endif %}
-
-
-    {{ return(
-        dbt_project_evaluator.select_from_values(
-            values = values,
-            column_names = [
-              'unique_id',
-              'name',
-              'file_path',
-              'alias',
-              'resource_type',
-              'source_name',
-              'is_source_described',
-              'is_described',
-              'is_enabled',
-              'loaded_at_field',
-              'database',
-              'schema',
-              'package_name',
-              'loader',
-              'identifier' 
-            ]
-         )
-    ) }}
+    
+    {% endif %}
  
 {% endmacro %}


### PR DESCRIPTION
…om values

This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

Closes #137 
Alternative to #144 


## Description & motivation
This is another approach to handling the situation where a project does not have a given node type available in the graph. The intended behavior of the project is to create an empty table with the correct column schema so that downstream models can still function. The crux of the issue comes down to how we cast null values to the correct data type. 

this PR

1. Adds a conditional check to each of the `get_<node_type>` macros to only call `select_from_values` when that resource type exists
2. adds the explicit SQL needed to create the model properly
3. Removes null handling logic from `select_from_values`

As @graciegoheen noted, this requires a) more code and b) more places to handle column names/types (albeit only in one macro file). The tradeoff here is explicitly writing out the backup SQL vs masking that complexity in the `select_from_values` macro. 

## Integration Test Screenshot
I ran this on both the normal integration tests projects, and a duplicate project I made that contained only one single model with no references to any other dbt object. 

<img width="754" alt="image" src="https://user-images.githubusercontent.com/73915542/175056854-29c0c172-47ac-4b77-8e49-3d5d7c6a20b2.png">


## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [x] Redshift
    - [x] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md