### PR TITLE
added new fct_chained_views_dependencies model - option 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,7 +724,7 @@ You can set your own threshold for chained views by overriding the `chained_view
 
 #### Reason to Flag
 
-You may experience a long runtime for a model when it is build on top of a long chain of "non-physically-materialized" models (views and ephemerals). Most of this runtime is actually *compilation* time. In the example above, nothing is really computed until you get to `table_1`. At which point, it is going to run the query within `view_4`, which will then have to run the query within `view_3`, which will then have the run the query within `view_2`, which will then have to run the query within `view_1`. These will all be running at the same time, which creates a long runtime for `table_3` and potential storage issues if the data is sufficiently large. 
+You may experience a long runtime for a model when it is build on top of a long chain of "non-physically-materialized" models (views and ephemerals). In the example above, nothing is really computed until you get to `table_1`. At which point, it is going to run the query within `view_4`, which will then have to run the query within `view_3`, which will then have the run the query within `view_2`, which will then have to run the query within `view_1`. These will all be running at the same time, which creates a long runtime for `table_3`. 
 
 #### How to Remediate
 

--- a/README.md
+++ b/README.md
@@ -709,13 +709,13 @@ A new yml file should be created in `marts/` which contains all tests and docume
 
 ## Performance
 ### Chained View Dependencies
+#### Model
 
 `fct_chained_views_dependencies` ([source](models/marts/performance/fct_chained_views_dependencies.sql)) contains models that are dependent on chains of "non-physically-materialized" models (views and ephemerals), highlighting potential cases for improving performance by switching the materialization of model(s) within the chain to table or incremental. 
 
 This model will raise a `warn` error on a `dbt build` or `dbt test` if the `distance` between a given `parent` and `child` is greater than 5.
 You can set your own threshold by overriding the `chained_views_threshold` variable. [See overriding variables section.](#overriding-variables)
 
-#### Model
 #### Reason to Flag
 #### How to Remediate
 #### Example
@@ -779,6 +779,7 @@ vars:
 ```
 
 #### Naming Convention Variables:
+
 | variable    | description | default     |
 | ----------- | ----------- | ----------- |
 | `model_types` | a list of the different types of models that define the layers of your dbt project | staging, intermediate, marts, other |
@@ -803,7 +804,22 @@ vars:
     util_prefixes: ['util_']
 ```
 
+#### Performance Variables:
+| variable    | description | default     |
+| ----------- | ----------- | ----------- |
+| `chained_views_threshold` | maximum threshold for acceptable length of chain of views for `fct_chained_views_dependencies` | 5 |
+
+```yml
+# dbt_project.yml
+# set your chained views threshold to 8 instead of 5
+
+vars:
+  dbt_project_evaluator:
+    chained_views_threshold: 8
+```
+
 #### Warehouse Specific Variables:
+
 | variable    | description | default     |
 | ----------- | ----------- | ----------- |
 | `max_depth_dag` | limits the number of looped CTEs when computing the DAG end-to-end for BigQuery and Databricks/Spark compatibility | 9 |

--- a/README.md
+++ b/README.md
@@ -750,6 +750,12 @@ A new yml file should be created in `marts/` which contains all tests and docume
 
 ## Performance
 ### Chained View Dependencies
+
+`fct_chained_views_dependencies` ([source](models/marts/performance/fct_chained_views_dependencies.sql)) contains models that are dependent on chains of "non-physically-materialized" models (views and ephemerals), highlighting potential cases for improving performance by switching the materialization of model(s) within the chain to table or incremental. 
+
+This model will raise a `warn` error on a `dbt build` or `dbt test` if the `distance` between a given `parent` and `child` is greater than 5.
+You can set your own threshold by overriding the `chained_views_threshold` variable. [See overriding variables section.](#overriding-variables)
+
 #### Model
 #### Reason to Flag
 #### How to Remediate

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Specifically, this package tests for:
   1. __[DAG Issues](#dag-issues)__ - your dbt DAG for modeling best practices
   2. __[Testing](#testing)__ - your models for testing best practices
   3. __[Documentation](#documentation)__ - your models for documentation best practices
-  3. __[Structure](#structure)__ - your dbt project for file structure and naming best practices
+  4. __[Structure](#structure)__ - your dbt project for file structure and naming best practices
+  5. __[Performance](#performance)__ - your model materializations for performance best practices
 
 In addition to tests, this package creates the model `int_all_dag_relationships` which holds information about your DAG in a tabular format and can be queried using SQL in your Warehouse.
 
@@ -114,6 +115,9 @@ __[Structure](#structure)__
 - [Model Directories](#model-directories)
 - [Source Directories](#model-directories)
 - [Test Directories](#test-directories)
+
+__[Performance](#performance)__
+- [Chained View Dependencies](#chained-view-dependencies)
 
 __[Customization](#customization)__
 - [Disabling Models](#disabling-models)
@@ -743,6 +747,13 @@ A new yml file should be created in `marts/` which contains all tests and docume
     └── staging
         ├── staging.yml
 ```
+
+## Performance
+### Chained View Dependencies
+#### Model
+#### Reason to Flag
+#### How to Remediate
+#### Example
 
 -----
 ## Customization

--- a/README.md
+++ b/README.md
@@ -826,7 +826,7 @@ vars:
 
 ```yml
 # dbt_project.yml
-# set your chained views threshold to 8 instead of 5
+# set your chained views threshold to 8 instead of 4
 
 vars:
   dbt_project_evaluator:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -72,5 +72,8 @@ vars:
   marts_prefixes: ['fct_', 'dim_']
   other_prefixes: ['rpt_']
 
+  # -- Performance variables --
+  chained_views_threshold: 5
+
   # -- Warehouse specific variables --
   max_depth_dag: 9

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -29,6 +29,9 @@ models:
         int_direct_relationships:
           # required for BigQuery and Redshift for performance/memory reasons
           +materialized: "{{ 'table' if target.type in ['bigquery', 'redshift', 'databricks'] else 'view' }}"
+        int_all_dag_relationships:
+          # required for BigQuery and Redshift for performance/memory reasons
+          +materialized: "{{ 'table' if target.type in ['bigquery', 'redshift'] else 'view' }}"
       dag:
         +materialized: table
     staging:

--- a/integration_tests/models/marts/fct_model_6.sql
+++ b/integration_tests/models/marts/fct_model_6.sql
@@ -1,1 +1,7 @@
-{{ ref('stg_model_3') }}
+{{
+  config(
+    materialized = 'table',
+    )
+}}
+
+select 1 from {{ ref('stg_model_3') }}

--- a/integration_tests/models/marts/fct_model_6.sql
+++ b/integration_tests/models/marts/fct_model_6.sql
@@ -4,4 +4,5 @@
     )
 }}
 
-select 1 from {{ ref('stg_model_3') }}
+select 1 as id 
+-- depends on: {{ ref('stg_model_3') }}

--- a/integration_tests/models/staging/source_1/stg_model_3.sql
+++ b/integration_tests/models/staging/source_1/stg_model_3.sql
@@ -1,1 +1,2 @@
-{{ source('source_2', 'table_3') }}
+-- depends on: {{ source('source_2', 'table_3') }}
+select 1 as id

--- a/integration_tests/seeds/performance/performance_seeds.yml
+++ b/integration_tests/seeds/performance/performance_seeds.yml
@@ -1,0 +1,12 @@
+version: 2
+
+seeds:
+  - name: test_fct_chained_views_dependencies
+    tests:
+      - dbt_utils.equality:
+          name: equality_fct_chained_views_dependencies
+          compare_model: ref('fct_chained_views_dependencies')
+          compare_columns:
+            - parent
+            - child
+            - distance

--- a/integration_tests/seeds/performance/test_fct_chained_views_dependencies.csv
+++ b/integration_tests/seeds/performance/test_fct_chained_views_dependencies.csv
@@ -1,0 +1,14 @@
+parent,child,distance
+stg_model_1,dim_model_7,3
+stg_model_1,int_model_5,2
+stg_model_2,dim_model_7,2
+int_model_4,dim_model_7,2
+stg_model_1,dim_model_7,2
+stg_model_4,dim_model_7,1
+stg_model_2,stg_model_4,1
+int_model_4,int_model_5,1
+int_model_5,dim_model_7,1
+stg_model_1,int_model_5,1
+stg_model_1,int_model_4,1
+fct_model_9,stg_model_5,1
+stg_model_3,fct_model_6,1

--- a/macros/recursive_dag.sql
+++ b/macros/recursive_dag.sql
@@ -92,7 +92,7 @@ all_relationships (
         case 
             when 
                 all_relationships.child_materialized in ('view', 'ephemeral') 
-                and ifnull(all_relationships.is_dependent_on_chain_of_views, true) 
+                and coalesce(all_relationships.is_dependent_on_chain_of_views, true) 
                 then true
             else false
         end as is_dependent_on_chain_of_views
@@ -150,7 +150,7 @@ with direct_relationships as (
         case 
             when 
                 cte_{{i - 1}}.child_materialized in ('view', 'ephemeral') 
-                and ifnull(cte_{{i - 1}}.is_dependent_on_chain_of_views, true) 
+                and coalesce(cte_{{i - 1}}.is_dependent_on_chain_of_views, true) 
                 then true
             else false
         end as is_dependent_on_chain_of_views

--- a/macros/recursive_dag.sql
+++ b/macros/recursive_dag.sql
@@ -20,6 +20,7 @@ all_relationships (
     parent,
     parent_resource_type,
     parent_model_type,
+    parent_materialized,
     parent_source_name,
     parent_file_path,
     parent_directory_path,
@@ -28,12 +29,14 @@ all_relationships (
     child,
     child_resource_type,
     child_model_type,
+    child_materialized,
     child_source_name,
     child_file_path,
     child_directory_path,
     child_file_name,
     distance,
-    path
+    path,
+    is_dependent_on_chain_of_views
 ) as (
     -- anchor 
     select distinct
@@ -41,6 +44,7 @@ all_relationships (
         resource_name as parent,
         resource_type as parent_resource_type,
         model_type as parent_model_type,
+        materialized as parent_materialized,
         source_name as parent_source_name,
         file_path as parent_file_path,
         directory_path as parent_directory_path,
@@ -49,15 +53,17 @@ all_relationships (
         resource_name as child,
         resource_type as child_resource_type,
         model_type as child_model_type,
+        materialized as child_materialized,
         source_name as child_source_name,
         file_path as child_file_path,
         directory_path as child_directory_path,
         file_name as child_file_name,
         0 as distance,
-        {{ dbt_utils.array_construct(['resource_name']) }} as path
+        {{ dbt_utils.array_construct(['resource_name']) }} as path,
+        null::boolean as is_dependent_on_chain_of_views
 
     from direct_relationships
-    -- where direct_parent is null {# optional lever to change filtering of anchor clause to only include root resources #}
+    -- where direct_parent_id is null {# optional lever to change filtering of anchor clause to only include root resources #}
     
     union all
 
@@ -67,6 +73,7 @@ all_relationships (
         all_relationships.parent as parent,
         all_relationships.parent_resource_type as parent_resource_type,
         all_relationships.parent_model_type as parent_model_type,
+        all_relationships.parent_materialized as parent_materialized,
         all_relationships.parent_source_name as parent_source_name,
         all_relationships.parent_file_path as parent_file_path,
         all_relationships.parent_directory_path as parent_directory_path,
@@ -75,12 +82,20 @@ all_relationships (
         direct_relationships.resource_name as child,
         direct_relationships.resource_type as child_resource_type,
         direct_relationships.model_type as child_model_type,
+        direct_relationships.materialized as child_materialized,
         direct_relationships.source_name as child_source_name,
         direct_relationships.file_path as child_file_path,
         direct_relationships.directory_path as child_directory_path,
         direct_relationships.file_name as child_file_name,
         all_relationships.distance+1 as distance, 
-        {{ dbt_utils.array_append('all_relationships.path', 'direct_relationships.resource_name') }} as path
+        {{ dbt_utils.array_append('all_relationships.path', 'direct_relationships.resource_name') }} as path,
+        case 
+            when 
+                all_relationships.child_materialized in ('view', 'ephemeral') 
+                and ifnull(all_relationships.is_dependent_on_chain_of_views, true) 
+                then true
+            else false
+        end as is_dependent_on_chain_of_views
 
     from direct_relationships
     inner join all_relationships
@@ -88,9 +103,6 @@ all_relationships (
 )
 
 {% endmacro %}
-
-
-
 
 
 {% macro bigquery__recursive_dag() %}
@@ -102,7 +114,7 @@ with direct_relationships as (
     select  
         *
     from {{ ref('int_direct_relationships') }}
-     where resource_type <> 'test'
+    where resource_type <> 'test'
 )
 
 -- must do distinct prior to creating array because BigQuery doesn't support distinct on array type
@@ -156,6 +168,7 @@ with direct_relationships as (
         parent.resource_name as parent,
         parent.resource_type as parent_resource_type,
         parent.model_type as parent_model_type,
+        parent.materialized as parent_materialized,
         parent.source_name as parent_source_name,
         parent.file_path as parent_file_path,
         parent.directory_path as parent_directory_path,
@@ -164,6 +177,7 @@ with direct_relationships as (
         child.resource_name as child,
         child.resource_type as child_resource_type,
         child.model_type as child_model_type,
+        child.materialized as child_materialized,
         child.source_name as child_source_name,
         child.file_path as child_file_path,
         child.directory_path as child_directory_path,

--- a/models/marts/core/int_direct_relationships.sql
+++ b/models/marts/core/int_direct_relationships.sql
@@ -10,6 +10,7 @@ all_graph_resources as (
         directory_path, 
         file_name,
         model_type,
+        materialized,
         source_name 
     from {{ ref('int_all_graph_resources') }}
 ),

--- a/models/marts/performance/fct_chained_views_dependencies.sql
+++ b/models/marts/performance/fct_chained_views_dependencies.sql
@@ -1,0 +1,21 @@
+with all_relationships as (
+    select  
+        *
+    from {{ ref('int_all_dag_relationships') }}
+    where distance <> 0
+),
+
+final as (
+    select
+        parent,
+        child, -- the model with potentially long run time / compilation time, improve performance by breaking the upstream chain of views
+        distance,
+        path,
+        is_dependent_on_chain_of_views
+    from all_relationships
+    where is_dependent_on_chain_of_views
+    and child_resource_type = 'model'
+)
+
+select * from final
+order by distance desc

--- a/models/marts/performance/fct_chained_views_dependencies.sql
+++ b/models/marts/performance/fct_chained_views_dependencies.sql
@@ -10,8 +10,7 @@ final as (
         parent,
         child, -- the model with potentially long run time / compilation time, improve performance by breaking the upstream chain of views
         distance,
-        path,
-        is_dependent_on_chain_of_views
+        path
     from all_relationships
     where is_dependent_on_chain_of_views
     and child_resource_type = 'model'

--- a/models/marts/performance/performance.yml
+++ b/models/marts/performance/performance.yml
@@ -11,4 +11,5 @@ models:
         tests:
           - dbt_utils.accepted_range:
               max_value: "{{ var('chained_views_threshold') }}"
+              inclusive: false
               severity: warn

--- a/models/marts/performance/performance.yml
+++ b/models/marts/performance/performance.yml
@@ -1,0 +1,14 @@
+version: 2 
+
+models: 
+  - name: fct_chained_views_dependencies
+    description: >
+      This model returns chains of "non-physically-materialized" models (views and ephemerals),
+      highlighting potential cases for improving performance by switching the
+      materialization of model(s) within the chain to table/incremental. 
+    columns:
+      - name: distance
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: "{{ var('chained_views_threshold') }}"
+              severity: warn

--- a/models/marts/performance/performance.yml
+++ b/models/marts/performance/performance.yml
@@ -3,12 +3,12 @@ version: 2
 models: 
   - name: fct_chained_views_dependencies
     description: >
-      This model returns chains of "non-physically-materialized" models (views and ephemerals),
-      highlighting potential cases for improving performance by switching the
-      materialization of model(s) within the chain to table/incremental. 
+      This returns models dependent on chains of "non-physically-materialized" models (views and ephemerals),
+      highlighting potential cases for improving performance by switching the materialization of model(s) within 
+      the chain to table or incremental. 
     columns:
       - name: distance
         tests:
           - dbt_utils.accepted_range:
-              min_value: "{{ var('chained_views_threshold') }}"
+              max_value: "{{ var('chained_views_threshold') }}"
               severity: warn


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes
- [x] new functionality

An alternative solution to #129 

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
- Created new model `fct_chained_views_dependencies` which returns the models that depend on a chain of views/ephemeral models
- Added new field `is_dependent_on_chain_of_views` to `int_all_dag_relationships`

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->
<img width="659" alt="Screen Shot 2022-06-27 at 2 57 02 PM" src="https://user-images.githubusercontent.com/53586774/176015291-7a05d995-464d-428e-8da3-c977b5d03adc.png">

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md