### PR TITLE
Added owner_name and owner_email fields 

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,7 +724,7 @@ You can set your own threshold for chained views by overriding the `chained_view
 
 #### Reason to Flag
 
-You may experience a long runtime for a model when it is build on top of a long chain of "non-physically-materialized" models (views and ephemerals). In the example above, nothing is really computed until you get to `table_1`. At which point, it is going to run the query within `view_4`, which will then have to run the query within `view_3`, which will then have the run the query within `view_2`, which will then have to run the query within `view_1`. These will all be running at the same time, which creates a long runtime for `table_3`. 
+You may experience a long runtime for a model when it is build on top of a long chain of "non-physically-materialized" models (views and ephemerals). In the example above, nothing is really computed until you get to `table_1`. At which point, it is going to run the query within `view_4`, which will then have to run the query within `view_3`, which will then have the run the query within `view_2`, which will then have to run the query within `view_1`. These will all be running at the same time, which creates a long runtime for `table_1`. 
 
 #### How to Remediate
 

--- a/macros/unpack/get_exposures.sql
+++ b/macros/unpack/get_exposures.sql
@@ -21,7 +21,9 @@
             '{{ node.type }}',
             '{{ node.maturity}}',
             '{{ node.package_name }}',
-            '{{ node.url }}'
+            '{{ node.url }}',
+            '{{ node.owner.name }}',
+            '{{ node.owner.email }}'
 
           {% endset -%}
           {%- do values.append(values_line) -%}
@@ -41,7 +43,9 @@
               'exposure_type', 
               'maturity', 
               'package_name', 
-              'url'
+              'url',
+              'owner_name',
+              'owner_email'
             ]
          )
     ) }}

--- a/models/marts/core/int_all_graph_resources.sql
+++ b/models/marts/core/int_all_graph_resources.sql
@@ -69,6 +69,8 @@ joined as (
         unioned_with_calc.exposure_type, 
         unioned_with_calc.maturity, 
         unioned_with_calc.url, 
+        unioned_with_calc.owner_name,
+        unioned_with_calc.owner_email,
         unioned_with_calc.metric_type, 
         unioned_with_calc.model, 
         unioned_with_calc.label, 


### PR DESCRIPTION
…graph_resources

This is a:
- [ ] bug fix PR with no breaking changes
- [x] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->

Closes #165 

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
- Add `owner_name` and `owner_email` fields to `stg_exposures` and `int_all_graph_resources`
- Fixed typo in README

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->
![Screen Shot 2022-07-06 at 9 47 42 AM](https://user-images.githubusercontent.com/53586774/177565315-7d400eb2-2c03-4727-b055-bfd36da2bcde.png)

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md