### PR TITLE
Feature - Add meta field as JSON string in `int_all_graph_resources`

### DIFF
--- a/integration_tests/models/marts/metrics.yml
+++ b/integration_tests/models/marts/metrics.yml
@@ -24,4 +24,6 @@ metrics:
         operator: '!='
         value: "Acme' Inc"
 
-    meta: {team: Finance}
+    meta: 
+      team: "Finance"
+      refresh_rate: "Bob's weekly run"

--- a/macros/unpack/get_exposures.sql
+++ b/macros/unpack/get_exposures.sql
@@ -23,7 +23,8 @@
             '{{ node.package_name }}',
             '{{ node.url }}',
             '{{ node.owner.name }}',
-            '{{ node.owner.email }}'
+            '{{ node.owner.email }}',
+            '{{ node.meta | tojson }}'
 
           {% endset -%}
           {%- do values.append(values_line) -%}
@@ -45,7 +46,8 @@
               'package_name', 
               'url',
               'owner_name',
-              'owner_email'
+              'owner_email',
+              'meta'
             ]
          )
     ) }}

--- a/macros/unpack/get_metrics.sql
+++ b/macros/unpack/get_metrics.sql
@@ -31,7 +31,8 @@
               {% endfor -%}
             {%- else -%}
                 ''
-            {% endif -%}
+            {% endif -%},
+            '{{ node.meta | tojson }}'
         {%- endset -%}
         {%- do values.append(values_line) -%}
 
@@ -54,7 +55,8 @@
               'timestamp', 
               'package_name',
               'dimensions',
-              'filters'
+              'filters',
+              'meta'
             ]
          )
     ) }}

--- a/macros/unpack/get_nodes.sql
+++ b/macros/unpack/get_nodes.sql
@@ -24,7 +24,8 @@
               '{{ node.package_name }}',
               '{{ node.alias }}',
               cast('{{ dbt_project_evaluator.is_not_empty_string(node.description) | trim }}' as boolean),
-              '{{ "" if not node.column_name else node.column_name }}'
+              '{{ "" if not node.column_name else node.column_name }}',
+              '{{ node.meta | tojson }}'
 
         {% endset -%}
         {%- do values.append(values_line) -%}
@@ -48,7 +49,8 @@
               'package_name',
               'alias',
               ('is_described', 'boolean'),
-              'column_name'
+              'column_name',
+              'meta'
             ]
          )
     ) }}

--- a/macros/unpack/get_sources.sql
+++ b/macros/unpack/get_sources.sql
@@ -26,7 +26,8 @@
               '{{ node.schema }}',
               '{{ node.package_name }}',
               '{{ node.loader }}',
-              '{{ node.identifier }}'
+              '{{ node.identifier }}',
+              '{{ node.meta | tojson }}'
 
         {% endset -%}
         {%- do values.append(values_line) -%}
@@ -53,7 +54,8 @@
               'schema',
               'package_name',
               'loader',
-              'identifier' 
+              'identifier',
+              'meta'
             ]
          )
     ) }}

--- a/models/marts/core/int_all_graph_resources.sql
+++ b/models/marts/core/int_all_graph_resources.sql
@@ -71,6 +71,7 @@ joined as (
         unioned_with_calc.url, 
         unioned_with_calc.owner_name,
         unioned_with_calc.owner_email,
+        unioned_with_calc.meta,
         unioned_with_calc.metric_type, 
         unioned_with_calc.model, 
         unioned_with_calc.label, 


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes
- [x] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #164
-->


## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Adds the meta field for all elements (sources, exposures, metrics, nodes) and store it as a JSON string. Each DW could then consume this column and use its own JSON parsing functions.


## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md