### PR TITLE
Fix - Make `values` a list of list, allowing to load fields with commas

### DIFF
--- a/integration_tests/models/marts/metrics.yml
+++ b/integration_tests/models/marts/metrics.yml
@@ -22,6 +22,6 @@ metrics:
         value: 'true'
       - field: company_name
         operator: '!='
-        value: "Acme' Inc"
+        value: "Acme', Inc"
 
     meta: {team: Finance}

--- a/macros/unpack/get_exposures.sql
+++ b/macros/unpack/get_exposures.sql
@@ -13,17 +13,17 @@
 
           {%- set values_line = 
             [
-              "'" ~ node.unique_id ~ "'",
-              "'" ~ node.name ~ "'",
-              "'" ~ node.resource_type ~ "'",
-              "'" ~ node.original_file_path ~ "'",
+              wrap_string_with_quotes(node.unique_id),
+              wrap_string_with_quotes(node.name),
+              wrap_string_with_quotes(node.resource_type),
+              wrap_string_with_quotes(node.original_file_path),
               "cast(" ~ dbt_project_evaluator.is_not_empty_string(node.description) | trim ~ " as boolean)",
-              "'" ~ node.type ~ "'",
-              "'" ~ node.maturity~ "'",
-              "'" ~ node.package_name ~ "'",
-              "'" ~ node.url ~ "'",
-              "'" ~ node.owner.name ~ "'",
-              "'" ~ node.owner.email~ "'"
+              wrap_string_with_quotes(node.type),
+              wrap_string_with_quotes(node.maturity),
+              wrap_string_with_quotes(node.package_name),
+              wrap_string_with_quotes(node.url),
+              wrap_string_with_quotes(node.owner.name),
+              wrap_string_with_quotes(node.owner.email)
             ]
           %}
 

--- a/macros/unpack/get_exposures.sql
+++ b/macros/unpack/get_exposures.sql
@@ -11,21 +11,22 @@
 
         {%- for node in nodes_list -%}
 
-          {%- set values_line %}
+          {%- set values_line = 
+            [
+              "'" ~ node.unique_id ~ "'",
+              "'" ~ node.name ~ "'",
+              "'" ~ node.resource_type ~ "'",
+              "'" ~ node.original_file_path ~ "'",
+              "cast(" ~ dbt_project_evaluator.is_not_empty_string(node.description) | trim ~ " as boolean)",
+              "'" ~ node.type ~ "'",
+              "'" ~ node.maturity~ "'",
+              "'" ~ node.package_name ~ "'",
+              "'" ~ node.url ~ "'",
+              "'" ~ node.owner.name ~ "'",
+              "'" ~ node.owner.email~ "'"
+            ]
+          %}
 
-            '{{ node.unique_id }}',
-            '{{ node.name }}',
-            '{{ node.resource_type }}',
-            '{{ node.original_file_path }}',
-            cast('{{ dbt_project_evaluator.is_not_empty_string(node.description) | trim }}'as boolean),
-            '{{ node.type }}',
-            '{{ node.maturity}}',
-            '{{ node.package_name }}',
-            '{{ node.url }}',
-            '{{ node.owner.name }}',
-            '{{ node.owner.email }}'
-
-          {% endset -%}
           {%- do values.append(values_line) -%}
 
     {%- endfor -%}

--- a/macros/unpack/get_metrics.sql
+++ b/macros/unpack/get_metrics.sql
@@ -10,20 +10,7 @@
 
     {%- for node in nodes_list -%}
 
-          {%- set values_line %}
-
-            '{{ node.unique_id }}',
-            '{{ node.name }}',
-            '{{ node.resource_type }}',
-            '{{ node.original_file_path }}',
-            cast('{{ dbt_project_evaluator.is_not_empty_string(node.description) | trim }}' as boolean),
-            '{{ node.type }}',
-            '{{ node.model.identifier }}',
-            '{{ node.label }}',
-            '{{ node.sql }}',
-            '{{ node.timestamp }}',
-            '{{ node.package_name }}',
-            '{{ node.dimensions|join(' - ') }}',
+          {% set metric_filters %}
             {%- if node.filters|length -%}
               {%- for filt in node.filters %}
                 '{{ filt.field }}'||'{{ filt.operator }}'||'''{{ dbt_utils.escape_single_quotes(filt.value) }}'''
@@ -32,7 +19,27 @@
             {%- else -%}
                 ''
             {% endif -%}
-        {%- endset -%}
+          {% endset %}
+
+          {%- set values_line = 
+            [
+            "'" ~ node.unique_id ~ "'",
+            "'" ~ node.name ~ "'",
+            "'" ~ node.resource_type ~ "'",
+            "'" ~ node.original_file_path ~ "'",
+            "cast(" ~ dbt_project_evaluator.is_not_empty_string(node.description) | trim ~ " as boolean)",
+            "'" ~ node.type ~ "'",
+            "'" ~ node.model.identifier ~ "'",
+            "'" ~ node.label ~ "'",
+            "'" ~ node.sql ~ "'",
+            "'" ~ node.timestamp ~ "'",
+            "'" ~ node.package_name ~ "'",
+            "'" ~ node.dimensions|join(' - ') ~ "'",
+            metric_filters,
+            "'" ~ node.meta | tojson ~ "'",
+            ]
+          %}
+
         {%- do values.append(values_line) -%}
 
     {%- endfor -%}
@@ -54,7 +61,8 @@
               'timestamp', 
               'package_name',
               'dimensions',
-              'filters'
+              'filters',
+              'meta'
             ]
          )
     ) }}

--- a/macros/unpack/get_metrics.sql
+++ b/macros/unpack/get_metrics.sql
@@ -23,18 +23,18 @@
 
           {%- set values_line = 
             [
-            "'" ~ node.unique_id ~ "'",
-            "'" ~ node.name ~ "'",
-            "'" ~ node.resource_type ~ "'",
-            "'" ~ node.original_file_path ~ "'",
+            wrap_string_with_quotes(node.unique_id),
+            wrap_string_with_quotes(node.name),
+            wrap_string_with_quotes(node.resource_type),
+            wrap_string_with_quotes(node.original_file_path),
             "cast(" ~ dbt_project_evaluator.is_not_empty_string(node.description) | trim ~ " as boolean)",
-            "'" ~ node.type ~ "'",
-            "'" ~ node.model.identifier ~ "'",
-            "'" ~ node.label ~ "'",
-            "'" ~ node.sql ~ "'",
-            "'" ~ node.timestamp ~ "'",
-            "'" ~ node.package_name ~ "'",
-            "'" ~ node.dimensions|join(' - ') ~ "'",
+            wrap_string_with_quotes(node.type),
+            wrap_string_with_quotes(node.model.identifier),
+            wrap_string_with_quotes(node.label),
+            wrap_string_with_quotes(node.sql),
+            wrap_string_with_quotes(node.timestamp),
+            wrap_string_with_quotes(node.package_name),
+            wrap_string_with_quotes(node.dimensions|join(' - ')),
             metric_filters
             ]
           %}

--- a/macros/unpack/get_metrics.sql
+++ b/macros/unpack/get_metrics.sql
@@ -35,8 +35,7 @@
             "'" ~ node.timestamp ~ "'",
             "'" ~ node.package_name ~ "'",
             "'" ~ node.dimensions|join(' - ') ~ "'",
-            metric_filters,
-            "'" ~ node.meta | tojson ~ "'",
+            metric_filters
             ]
           %}
 
@@ -61,8 +60,7 @@
               'timestamp', 
               'package_name',
               'dimensions',
-              'filters',
-              'meta'
+              'filters'
             ]
          )
     ) }}

--- a/macros/unpack/get_nodes.sql
+++ b/macros/unpack/get_nodes.sql
@@ -12,19 +12,19 @@
 
         {%- set values_line  = 
             [
-                "'" ~ node.unique_id ~ "'",
-                "'" ~ node.name ~ "'",
-                "'" ~ node.resource_type ~ "'",
-                "'" ~ node.original_file_path ~ "'",
+                wrap_string_with_quotes(node.unique_id),
+                wrap_string_with_quotes(node.name),
+                wrap_string_with_quotes(node.resource_type),
+                wrap_string_with_quotes(node.original_file_path),
                 "cast(" ~ node.config.enabled | trim ~ " as boolean)",
-                "'" ~ node.config.materialized ~ "'",
-                "'" ~ node.config.on_schema_chang ~ "'",
-                "'" ~ node.database ~ "'",
-                "'" ~ node.schema ~ "'",
-                "'" ~ node.package_name ~ "'",
-                "'" ~ node.alias ~ "'",
+                wrap_string_with_quotes(node.config.materialized),
+                wrap_string_with_quotes(node.config.on_schema_chang),
+                wrap_string_with_quotes(node.database),
+                wrap_string_with_quotes(node.schema),
+                wrap_string_with_quotes(node.package_name),
+                wrap_string_with_quotes(node.alias),
                 "cast(" ~ dbt_project_evaluator.is_not_empty_string(node.description) | trim ~ " as boolean)",
-                "''" if not node.column_name else "'" ~ node.column_name ~ "'"
+                "''" if not node.column_name else wrap_string_with_quotes(node.column_name)
             ]
         %}
 

--- a/macros/unpack/get_nodes.sql
+++ b/macros/unpack/get_nodes.sql
@@ -10,23 +10,24 @@
 
     {%- for node in nodes_list -%}
 
-          {%- set values_line %}
+        {%- set values_line  = 
+            [
+                "'" ~ node.unique_id ~ "'",
+                "'" ~ node.name ~ "'",
+                "'" ~ node.resource_type ~ "'",
+                "'" ~ node.original_file_path ~ "'",
+                "cast(" ~ node.config.enabled | trim ~ " as boolean)",
+                "'" ~ node.config.materialized ~ "'",
+                "'" ~ node.config.on_schema_chang ~ "'",
+                "'" ~ node.database ~ "'",
+                "'" ~ node.schema ~ "'",
+                "'" ~ node.package_name ~ "'",
+                "'" ~ node.alias ~ "'",
+                "cast(" ~ dbt_project_evaluator.is_not_empty_string(node.description) | trim ~ " as boolean)",
+                "''" if not node.column_name else "'" ~ node.column_name ~ "'"
+            ]
+        %}
 
-              '{{ node.unique_id }}',
-              '{{ node.name }}',
-              '{{ node.resource_type }}',
-              '{{ node.original_file_path }}',
-              cast('{{ node.config.enabled | trim }}' as boolean),
-              '{{ node.config.materialized }}',
-              '{{ node.config.on_schema_change}}',
-              '{{ node.database }}',
-              '{{ node.schema }}',
-              '{{ node.package_name }}',
-              '{{ node.alias }}',
-              cast('{{ dbt_project_evaluator.is_not_empty_string(node.description) | trim }}' as boolean),
-              '{{ "" if not node.column_name else node.column_name }}'
-
-        {% endset -%}
         {%- do values.append(values_line) -%}
 
     {%- endfor -%}

--- a/macros/unpack/get_relationships.sql
+++ b/macros/unpack/get_relationships.sql
@@ -22,18 +22,26 @@
 
             {%- if node.depends_on.nodes|length == 0 -%}
 
-                {%- set values_line %}
-                  cast('{{ node.unique_id }}' as {{ dbt_utils.type_string() }}),cast(NULL as {{ dbt_utils.type_string() }})
-                {% endset -%}
+                {%- set values_line = 
+                  [
+                    "cast('" ~ node.unique_id ~ "' as " ~ dbt_utils.type_string() ~ ")",
+                    "cast(NULL as " ~ dbt_utils.type_string() ~ ")"
+                  ] 
+                %}
+                  
                 {%- do values.append(values_line) -%}
 
             {%- else -%}       
 
                 {%- for parent in node.depends_on.nodes -%}
 
-                    {%- set values_line %}
-                      cast('{{ node.unique_id }}' as {{ dbt_utils.type_string() }}),cast('{{ parent }}' as {{ dbt_utils.type_string() }})
-                    {% endset -%}
+                    {%- set values_line = 
+                        [
+                            "cast('" ~ node.unique_id ~ "' as " ~ dbt_utils.type_string() ~ ")",
+                            "cast('" ~ parent ~ "' as " ~ dbt_utils.type_string() ~ ")"
+                        ]
+                    %}
+                      
                     {%- do values.append(values_line) -%}
 
                 {%- endfor -%}

--- a/macros/unpack/get_sources.sql
+++ b/macros/unpack/get_sources.sql
@@ -12,21 +12,21 @@
 
          {%- set values_line = 
             [
-              "'" ~ node.unique_id ~ "'",
-              "'" ~ node.name ~ "'",
-              "'" ~ node.original_file_path ~ "'",
-              "'" ~ node.alias ~ "'",
-              "'" ~ node.resource_type ~ "'",
-              "'" ~ node.source_name ~ "'",
+              wrap_string_with_quotes(node.unique_id),
+              wrap_string_with_quotes(node.name),
+              wrap_string_with_quotes(node.original_file_path),
+              wrap_string_with_quotes(node.alias),
+              wrap_string_with_quotes(node.resource_type),
+              wrap_string_with_quotes(node.source_name),
               "cast(" ~ dbt_project_evaluator.is_not_empty_string(node.source_description) | trim ~ " as boolean)",
               "cast(" ~ dbt_project_evaluator.is_not_empty_string(node.description) | trim ~ " as boolean)",
               "cast(" ~ node.config.enabled ~ " as boolean)",
-              "'" ~ node.loaded_at_field | replace("'", "_") ~ "'",
-              "'" ~ node.database ~ "'",
-              "'" ~ node.schema ~ "'",
-              "'" ~ node.package_name ~ "'",
-              "'" ~ node.loader ~ "'",
-              "'" ~ node.identifier ~ "'",
+              wrap_string_with_quotes(node.loaded_at_field | replace("'", "_")),
+              wrap_string_with_quotes(node.database),
+              wrap_string_with_quotes(node.schema),
+              wrap_string_with_quotes(node.package_name),
+              wrap_string_with_quotes(node.loader),
+              wrap_string_with_quotes(node.identifier),
             ]
         %}
             

--- a/macros/unpack/get_sources.sql
+++ b/macros/unpack/get_sources.sql
@@ -10,25 +10,26 @@
 
     {%- for node in nodes_list -%}
 
-         {%- set values_line %}
+         {%- set values_line = 
+            [
+              "'" ~ node.unique_id ~ "'",
+              "'" ~ node.name ~ "'",
+              "'" ~ node.original_file_path ~ "'",
+              "'" ~ node.alias ~ "'",
+              "'" ~ node.resource_type ~ "'",
+              "'" ~ node.source_name ~ "'",
+              "cast(" ~ dbt_project_evaluator.is_not_empty_string(node.source_description) | trim ~ " as boolean)",
+              "cast(" ~ dbt_project_evaluator.is_not_empty_string(node.description) | trim ~ " as boolean)",
+              "cast(" ~ node.config.enabled ~ " as boolean)",
+              "'" ~ node.loaded_at_field | replace("'", "_") ~ "'",
+              "'" ~ node.database ~ "'",
+              "'" ~ node.schema ~ "'",
+              "'" ~ node.package_name ~ "'",
+              "'" ~ node.loader ~ "'",
+              "'" ~ node.identifier ~ "'",
+            ]
+        %}
             
-              '{{ node.unique_id }}', 
-              '{{ node.name }}',
-              '{{ node.original_file_path }}',
-              '{{ node.alias }}',
-              '{{ node.resource_type }}',
-              '{{ node.source_name }}',
-              cast('{{ dbt_project_evaluator.is_not_empty_string(node.source_description) | trim }}' as boolean),
-              cast('{{ dbt_project_evaluator.is_not_empty_string(node.description) | trim }}' as boolean),
-              cast('{{ node.config.enabled }}' as boolean),
-              '{{ node.loaded_at_field | replace("'", "_") }}',
-              '{{ node.database }}',
-              '{{ node.schema }}',
-              '{{ node.package_name }}',
-              '{{ node.loader }}',
-              '{{ node.identifier }}'
-
-        {% endset -%}
         {%- do values.append(values_line) -%}
 
     {%- endfor -%}

--- a/macros/wrap_string_with_quotes.sql
+++ b/macros/wrap_string_with_quotes.sql
@@ -1,0 +1,3 @@
+{% macro wrap_string_with_quotes(str) %}
+  {{ return("'" ~ str ~ "'") }}
+{% endmacro %}

--- a/models/staging/graph/graph.yml
+++ b/models/staging/graph/graph.yml
@@ -14,4 +14,4 @@ macros:
 
       - name: values
         type: list
-        description: The list of values to be inserted in the view/table. Each item of the list has the format "('value_col1', 'value_col2', 'value_col3')"
+        description: The list of values to be inserted in the view/table. Each item of the list is a list itself, like ['value_col1', 'value_col2', 'value_col3']


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
-->
Closes #170



## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Changing the logic of the different ingestion macros and `select_from_values` to make values a list of lists. We used to have it as a list of strings and split by `,` for BigQuery and Redshift but it doesn't work if there is a `,` in a field, like `meta` or if we want to load a JSON string in a column.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md