### PR TITLE
add needed marts directory to disabling models example

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,13 +766,14 @@ disable these models as you would any other model in your `dbt_project.yml` file
 
 models:
   dbt_project_evaluator:
-    tests:
-      # disable entire test coverage suite
-      +enabled: false
-    dag:
-      # disable single DAG model
-      fct_model_fanout:
+    marts:
+      tests:
+        # disable entire test coverage suite
         +enabled: false
+      dag:
+        # disable single DAG model
+        fct_model_fanout:
+          +enabled: false
 
 ```
 


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality


## Description & motivation
The current example returns an `unused configuration paths` error, since the listed models are actually within marts :)

## Integration Test Screenshot
N/A

## Checklist
- [x ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [x ] I have updated the README.md (if applicable)
- [N/A ] I have added tests & descriptions to my models (and macros if applicable)
- [N/A ] I have added an entry to CHANGELOG.md