### PR TITLE
Escape \ in the paths for Windows

### DIFF
--- a/macros/unpack/get_exposures.sql
+++ b/macros/unpack/get_exposures.sql
@@ -16,7 +16,7 @@
               wrap_string_with_quotes(node.unique_id),
               wrap_string_with_quotes(node.name),
               wrap_string_with_quotes(node.resource_type),
-              wrap_string_with_quotes(node.original_file_path),
+              wrap_string_with_quotes(node.original_file_path | replace("\\","\\\\")),
               "cast(" ~ dbt_project_evaluator.is_not_empty_string(node.description) | trim ~ " as boolean)",
               wrap_string_with_quotes(node.type),
               wrap_string_with_quotes(node.maturity),

--- a/macros/unpack/get_metrics.sql
+++ b/macros/unpack/get_metrics.sql
@@ -26,7 +26,7 @@
             wrap_string_with_quotes(node.unique_id),
             wrap_string_with_quotes(node.name),
             wrap_string_with_quotes(node.resource_type),
-            wrap_string_with_quotes(node.original_file_path),
+            wrap_string_with_quotes(node.original_file_path | replace("\\","\\\\")),
             "cast(" ~ dbt_project_evaluator.is_not_empty_string(node.description) | trim ~ " as boolean)",
             wrap_string_with_quotes(node.type),
             wrap_string_with_quotes(node.model.identifier),

--- a/macros/unpack/get_nodes.sql
+++ b/macros/unpack/get_nodes.sql
@@ -15,7 +15,7 @@
                 wrap_string_with_quotes(node.unique_id),
                 wrap_string_with_quotes(node.name),
                 wrap_string_with_quotes(node.resource_type),
-                wrap_string_with_quotes(node.original_file_path),
+                wrap_string_with_quotes(node.original_file_path | replace("\\","\\\\")),
                 "cast(" ~ node.config.enabled | trim ~ " as boolean)",
                 wrap_string_with_quotes(node.config.materialized),
                 wrap_string_with_quotes(node.config.on_schema_change),

--- a/macros/unpack/get_sources.sql
+++ b/macros/unpack/get_sources.sql
@@ -14,7 +14,7 @@
             [
               wrap_string_with_quotes(node.unique_id),
               wrap_string_with_quotes(node.name),
-              wrap_string_with_quotes(node.original_file_path),
+              wrap_string_with_quotes(node.original_file_path | replace("\\","\\\\")),
               wrap_string_with_quotes(node.alias),
               wrap_string_with_quotes(node.resource_type),
               wrap_string_with_quotes(node.source_name),


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->
Closes #163 


## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Escaping `\` by using `\\` as `\` is used in Warehouses for special characters, e.g. `\t` for tab etc...
The main issue is with `\u` which expects a unicode number.

We could add a folder called `som\uthing` in our integration test project but it doesn't feel right. I have tested it locally anyway on BQ, Postgres and Snowflake and it worked with a `\u` in a filename.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md