### PR TITLE
loop through all model_types for coverage models

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,10 +438,11 @@ in the `tests` directory of you project.
 Specifically, this models measures:
 1. `test_coverage_pct`: the percentage of your models that have minimum 1 test applied.
 2. `test_to_model_ratio`: the ratio of the number of tests in your dbt project to the number of models in your dbt project
-3. `marts_test_coverage_pct`: the percentage of your marts models that have minimum 1 test applied.
+3. `< model_type >_test_coverage_pct`: the percentage of each of your model types that have minimum 1 test applied.
 
 This model will raise a `warn` error on a `dbt build` or `dbt test` if the `test_coverage_pct` is less than 100%.
-You can set your own threshold by overriding the `test_coverage_target` variable. [See overriding variables section.](#overriding-variables)
+You can set your own threshold by overriding the `test_coverage_target` variable. 
+You can adjust your own model types by overriding the `model_types` variable. [See overriding variables section.](#overriding-variables)
 
 #### Reason to Flag
 We recommend that every model in your dbt project has tests applied to ensure the accuracy of your data transformations.

--- a/integration_tests/seeds/docs/docs_seeds.yml
+++ b/integration_tests/seeds/docs/docs_seeds.yml
@@ -12,6 +12,11 @@ seeds:
 
   - name: test_fct_documentation_coverage
     config:
+      column_types:
+        staging_documentation_coverage_pct: float
+        intermediate_documentation_coverage_pct: float
+        marts_documentation_coverage_pct: float
+        other_documentation_coverage_pct: float
       tags:
         - docs
     tests:

--- a/integration_tests/seeds/docs/docs_seeds.yml
+++ b/integration_tests/seeds/docs/docs_seeds.yml
@@ -13,10 +13,10 @@ seeds:
   - name: test_fct_documentation_coverage
     config:
       column_types:
-        staging_documentation_coverage_pct: float
-        intermediate_documentation_coverage_pct: float
-        marts_documentation_coverage_pct: float
-        other_documentation_coverage_pct: float
+        staging_documentation_coverage_pct: "{{ 'float' if target.type not in ['spark','databricks'] else 'decimal(10,2)' }}" 
+        intermediate_documentation_coverage_pct: "{{ 'float' if target.type not in ['spark','databricks'] else 'decimal(10,2)' }}" 
+        marts_documentation_coverage_pct: "{{ 'float' if target.type not in ['spark','databricks'] else 'decimal(10,2)' }}" 
+        other_documentation_coverage_pct: "{{ 'float' if target.type not in ['spark','databricks'] else 'decimal(10,2)' }}" 
       tags:
         - docs
     tests:

--- a/integration_tests/seeds/docs/docs_seeds.yml
+++ b/integration_tests/seeds/docs/docs_seeds.yml
@@ -24,4 +24,7 @@ seeds:
             - total_models
             - documented_models
             - documentation_coverage_pct
+            - staging_documentation_coverage_pct
+            - intermediate_documentation_coverage_pct
             - marts_documentation_coverage_pct
+            - other_documentation_coverage_pct

--- a/integration_tests/seeds/docs/docs_seeds.yml
+++ b/integration_tests/seeds/docs/docs_seeds.yml
@@ -12,8 +12,6 @@ seeds:
 
   - name: test_fct_documentation_coverage
     config:
-      column_types:
-        marts_documentation_coverage_pct: float
       tags:
         - docs
     tests:

--- a/integration_tests/seeds/docs/test_fct_documentation_coverage.csv
+++ b/integration_tests/seeds/docs/test_fct_documentation_coverage.csv
@@ -1,2 +1,2 @@
-total_models,documented_models,documentation_coverage_pct,marts_documentation_coverage_pct
-14,3,21.43,0.00
+total_models,documented_models,documentation_coverage_pct,staging_documentation_coverage_pct,intermediate_documentation_coverage_pct,marts_documentation_coverage_pct,other_documentation_coverage_pct
+14,3,21.43,20.00,0.00,0.00,66.67

--- a/integration_tests/seeds/tests/test_fct_test_coverage.csv
+++ b/integration_tests/seeds/tests/test_fct_test_coverage.csv
@@ -1,2 +1,2 @@
-﻿total_models,total_tests,tested_models,test_coverage_pct,test_to_model_ratio,marts_test_coverage_pct
-14,7,4,28.57,0.5,0.00
+﻿total_models,total_tests,tested_models,test_coverage_pct,staging_test_coverage_pct,intermediate_test_coverage_pct,marts_test_coverage_pct,other_test_coverage_pct,test_to_model_ratio
+14,7,4,28.57,60.00,50.00,0.00,0.00,0.5

--- a/integration_tests/seeds/tests/tests_seeds.yml
+++ b/integration_tests/seeds/tests/tests_seeds.yml
@@ -8,6 +8,12 @@ seeds:
           compare_model: ref('fct_missing_primary_key_tests')
 
   - name: test_fct_test_coverage
+    config:
+      column_types:
+        staging_test_coverage_pct: float
+        intermediate_test_coverage_pct: float
+        marts_test_coverage_pct: float
+        other_test_coverage_pct: float
     tests:
       - dbt_utils.equality:
           name: equality_fct_test_coverage

--- a/integration_tests/seeds/tests/tests_seeds.yml
+++ b/integration_tests/seeds/tests/tests_seeds.yml
@@ -21,4 +21,7 @@ seeds:
             - tested_models
             - test_coverage_pct
             - test_to_model_ratio
+            - staging_test_coverage_pct
+            - intermediate_test_coverage_pct
             - marts_test_coverage_pct
+            - other_test_coverage_pct

--- a/integration_tests/seeds/tests/tests_seeds.yml
+++ b/integration_tests/seeds/tests/tests_seeds.yml
@@ -8,9 +8,6 @@ seeds:
           compare_model: ref('fct_missing_primary_key_tests')
 
   - name: test_fct_test_coverage
-    config:
-      column_types:
-        marts_test_coverage_pct: float
     tests:
       - dbt_utils.equality:
           name: equality_fct_test_coverage

--- a/models/marts/documentation/fct_documentation_coverage.sql
+++ b/models/marts/documentation/fct_documentation_coverage.sql
@@ -8,7 +8,7 @@ models as (
 conversion as (
     select
         resource_id,
-        case when is_described then 1.0 else 0 end as is_described_model,
+        case when is_described then 1 else 0 end as is_described_model,
         {% for model_type in var('model_types') %}
             case when model_type = '{{ model_type }}' then 1.0 else NULL end as is_{{ model_type }}_model,
             case when is_described and model_type = '{{ model_type }}' then 1.0 else 0 end as is_described_{{ model_type }}_model{% if not loop.last %},{% endif %}
@@ -22,7 +22,7 @@ final as (
         current_timestamp as measured_at,
         count(*) as total_models,
         sum(is_described_model) as documented_models,
-        round(sum(is_described_model) * 100 / count(*), 2) as documentation_coverage_pct,
+        round(sum(is_described_model) * 100.0 / count(*), 2) as documentation_coverage_pct,
         {% for model_type in var('model_types') %}
             round(sum(is_described_{{ model_type }}_model) * 100 / count(is_{{ model_type }}_model), 2) as {{ model_type }}_documentation_coverage_pct{% if not loop.last %},{% endif %}
         {% endfor %}

--- a/models/marts/documentation/fct_documentation_coverage.sql
+++ b/models/marts/documentation/fct_documentation_coverage.sql
@@ -9,8 +9,10 @@ conversion as (
     select
         resource_id,
         case when is_described then 1.0 else 0 end as is_described_model,
-        case when model_type = 'marts' then 1.0 else NULL end as is_marts_model,
-        case when is_described and model_type = 'marts' then 1.0 else 0 end as is_described_marts_model
+        {% for model_type in var('model_types') %}
+            case when model_type = '{{ model_type }}' then 1.0 else NULL end as is_{{ model_type }}_model,
+            case when is_described and model_type = '{{ model_type }}' then 1.0 else 0 end as is_described_{{ model_type }}_model{% if not loop.last %},{% endif %}
+        {% endfor %}
 
     from models
 ),
@@ -21,7 +23,9 @@ final as (
         count(*) as total_models,
         sum(is_described_model) as documented_models,
         round(sum(is_described_model) * 100 / count(*), 2) as documentation_coverage_pct,
-        round(sum(is_described_marts_model) * 100 / count(is_marts_model), 2) as marts_documentation_coverage_pct
+        {% for model_type in var('model_types') %}
+            round(sum(is_described_{{ model_type }}_model) * 100 / count(is_{{ model_type }}_model), 2) as {{ model_type }}_documentation_coverage_pct{% if not loop.last %},{% endif %}
+        {% endfor %}
 
     from models
     left join conversion


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->
Closes #181

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Updated `fct_documentation_coverage` and `fct_test_coverage` to return the `_coverage_pct` for _each_ `model_type` listed in the `model_types` variable in your dbt_project.yml. 

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->
![Screen Shot 2022-08-03 at 3 58 33 PM](https://user-images.githubusercontent.com/53586774/182697996-efb4dd02-0d20-4bff-8691-cec2ac80341e.png)

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md