### PR TITLE
fix multi ref tests - alt approach

### DIFF
--- a/integration_tests/models/staging/staging.yml
+++ b/integration_tests/models/staging/staging.yml
@@ -7,6 +7,9 @@ models:
         tests:
           - unique
           - not_null
+          - relationships:
+              to: ref('stg_model_2')
+              field: id
 
   - name: int_model_4
     columns:

--- a/integration_tests/seeds/tests/test_fct_test_coverage.csv
+++ b/integration_tests/seeds/tests/test_fct_test_coverage.csv
@@ -1,2 +1,2 @@
 ﻿total_models,total_tests,tested_models,test_coverage_pct,test_to_model_ratio,marts_test_coverage_pct
-14,7,4,28.57,0.5,0.00
+14,8,4,28.57,0.5714,0.00

--- a/macros/unpack/get_relationships.sql
+++ b/macros/unpack/get_relationships.sql
@@ -5,7 +5,6 @@
 {%- macro default__get_relationships(node_type) -%}
 
     {%- if execute -%}
-
         {%- if node_type == 'nodes' %}
             {% set nodes_list = graph.nodes.values() %}   
         {%- elif node_type == 'exposures' -%}
@@ -25,7 +24,8 @@
                 {%- set values_line = 
                   [
                     "cast('" ~ node.unique_id ~ "' as " ~ dbt_utils.type_string() ~ ")",
-                    "cast(NULL as " ~ dbt_utils.type_string() ~ ")"
+                    "cast(NULL as " ~ dbt_utils.type_string() ~ ")",
+                    "FALSE",
                   ] 
                 %}
                   
@@ -38,7 +38,8 @@
                     {%- set values_line = 
                         [
                             "cast('" ~ node.unique_id ~ "' as " ~ dbt_utils.type_string() ~ ")",
-                            "cast('" ~ parent ~ "' as " ~ dbt_utils.type_string() ~ ")"
+                            "cast('" ~ parent ~ "' as " ~ dbt_utils.type_string() ~ ")",
+                            "" ~ loop.last ~ ""
                         ]
                     %}
                       
@@ -55,7 +56,8 @@
             values = values,
             columns = [
                 'resource_id',
-                'direct_parent_id'
+                'direct_parent_id',
+                'is_primary_relationship'
             ]
          )
     ) }}

--- a/models/marts/structure/fct_test_directories.sql
+++ b/models/marts/structure/fct_test_directories.sql
@@ -21,6 +21,7 @@ models_per_test as (
         direct_parent_id as parent_model_id
     from relationships
     where resource_type = 'test'
+    and is_primary_test_relationship
 
 ),
 

--- a/models/marts/tests/intermediate/int_model_test_summary.sql
+++ b/models/marts/tests/intermediate/int_model_test_summary.sql
@@ -19,6 +19,7 @@ count_column_tests as (
     left join relationships
         on all_graph_resources.resource_id = relationships.resource_id
     where all_graph_resources.resource_type = 'test'
+    and relationships.is_primary_test_relationship
     group by 1,2
 ),
 


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
Closes #172 

## Description & motivation

Based on the feedback from the team in Slack, and in the prior PR, I thought this would be a cleaner approach. This creates a new boolean dimension for whether the test-model relationship is the primary relationship based on the test naming convention. Whichever model appears earlier in the test name would be considered the primary, and should map to the model in the user's yml file that has the test applied to it. There may be another simpler way to do this with the unpack macros, so keen to get some eyes on this!

This makes it such that the edits to the fct models only need to be a simple filter for the primary test/model relationship, and the logic remains relatively unchanged. 

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md