### PR TITLE
Fix - Issue when columns are defined with quotes (e.g. SQL columns)

### DIFF
--- a/integration_tests/models/staging/staging.yml
+++ b/integration_tests/models/staging/staging.yml
@@ -7,9 +7,9 @@ models:
         tests:
           - unique
           - not_null
-      - name: "concat(coalesce(id,1),' - ','test_sql_column')"
+      - name: "concat('fake','column','for','testing')"
         tests:
-          - unique
+          - not_null
 
   - name: int_model_4
     columns:

--- a/integration_tests/models/staging/staging.yml
+++ b/integration_tests/models/staging/staging.yml
@@ -7,7 +7,7 @@ models:
         tests:
           - unique
           - not_null
-      - name: "concat('fake','column','for','testing')"
+      - name: "concat(coalesce('fake_column', ' '),'for_testing')"
         tests:
           - not_null
 

--- a/integration_tests/models/staging/staging.yml
+++ b/integration_tests/models/staging/staging.yml
@@ -7,6 +7,9 @@ models:
         tests:
           - unique
           - not_null
+      - name: "concat(coalesce(id,1),' - ','test_sql_column')"
+        tests:
+          - unique
 
   - name: int_model_4
     columns:

--- a/integration_tests/seeds/tests/test_fct_test_coverage.csv
+++ b/integration_tests/seeds/tests/test_fct_test_coverage.csv
@@ -1,2 +1,2 @@
 ﻿total_models,total_tests,tested_models,test_coverage_pct,staging_test_coverage_pct,intermediate_test_coverage_pct,marts_test_coverage_pct,other_test_coverage_pct,test_to_model_ratio
-14,7,4,28.57,60.00,50.00,0.00,0.00,0.5
+14,8,4,28.57,60.00,50.00,0.00,0.00,0.5714

--- a/macros/select_from_values.sql
+++ b/macros/select_from_values.sql
@@ -46,7 +46,7 @@
       {%- do values_list_of_strings.append( indiv_values | join(", \n")) -%}
     {%- endfor -%}
 
-    {%- set values_string = '(' ~ values_list_of_strings | join("), (") ~ ')' -%}
+    {%- set values_string = '(' ~ values_list_of_strings | join("), \n\n(") ~ ')' -%}
 
         with cte as (
 
@@ -76,10 +76,10 @@
         {%- set following_rows_list_of_strings = [] -%}
 
         {%- for values_row in values[1:] -%}
-            {%- do following_rows_list_of_strings.append( values_row | join(", ")) -%}
+            {%- do following_rows_list_of_strings.append( values_row | join(", \n")) -%}
         {%- endfor -%}
 
-        {%- set following_rows = '(' ~ following_rows_list_of_strings | join("), (") ~ ')' -%}
+        {%- set following_rows = '(' ~ following_rows_list_of_strings | join("), \n\n(") ~ ')' -%}
 
         {%- set struct_header = [] %}
         {%- for column in column_names -%}

--- a/macros/unpack/get_nodes.sql
+++ b/macros/unpack/get_nodes.sql
@@ -24,7 +24,7 @@
                 wrap_string_with_quotes(node.package_name),
                 wrap_string_with_quotes(node.alias),
                 "cast(" ~ dbt_project_evaluator.is_not_empty_string(node.description) | trim ~ " as boolean)",
-                "''" if not node.column_name else wrap_string_with_quotes(node.column_name),
+                "''" if not node.column_name else wrap_string_with_quotes(dbt_utils.escape_single_quotes(node.column_name)),
                 wrap_string_with_quotes(node.meta | tojson)
             ]
         %}


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->
Fixes #185 


## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
- The solution is to escape single quotes in the column name from the `graph`
- I have added a passing test for the feature
- I have also improved the SQL output for BQ `stg` models by adding a few newlines.

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md