### PR TITLE
distinct source to model relationships

### DIFF
--- a/integration_tests/models/staging/source_1/stg_model_1.sql
+++ b/integration_tests/models/staging/source_1/stg_model_1.sql
@@ -1,5 +1,6 @@
 -- this needs to be valid SQL for the fake test to run
 -- depends on: {{ source('source_1', 'table_1') }}
+-- depends on: {{ source('source_1', 'table_1') }}
 select 1 as id 
 union all 
 select 2 as id

--- a/integration_tests_2/models/staging/source_1/stg_model_2.sql
+++ b/integration_tests_2/models/staging/source_1/stg_model_2.sql
@@ -1,4 +1,5 @@
 -- depends on: {{ source('source_1', 'table_1') }}
+-- depends on: {{ source('source_1', 'table_1') }}
 -- depends on: {{ source('source_1', 'table_2') }}
 
 select 1 as id

--- a/integration_tests_2/models/staging/source_1/stg_model_2.sql
+++ b/integration_tests_2/models/staging/source_1/stg_model_2.sql
@@ -1,5 +1,4 @@
 -- depends on: {{ source('source_1', 'table_1') }}
--- depends on: {{ source('source_1', 'table_1') }}
 -- depends on: {{ source('source_1', 'table_2') }}
 
 select 1 as id

--- a/models/marts/dag/fct_multiple_sources_joined.sql
+++ b/models/marts/dag/fct_multiple_sources_joined.sql
@@ -1,6 +1,6 @@
 -- this model finds cases where a model references more than one source
 with direct_source_relationships as (
-    select  
+    select distinct
         *
     from {{ ref('int_all_dag_relationships') }}
     where distance = 1

--- a/models/marts/dag/fct_multiple_sources_joined.sql
+++ b/models/marts/dag/fct_multiple_sources_joined.sql
@@ -1,7 +1,8 @@
 -- this model finds cases where a model references more than one source
 with direct_source_relationships as (
     select distinct
-        *
+        child,
+        parent
     from {{ ref('int_all_dag_relationships') }}
     where distance = 1
     and parent_resource_type = 'source'


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
 
Closes #196 


## Description & motivation
This fix addresses an issue where multiple source references to the _same source_ in a model causes the `fct_multiple_sources` joined model to flag that as an error. There are some cases, like using the `dbt_utils.star` macro, that require you to use the source macro twice:

```sql 

-- in star.sql
select
  {{ dbt_utils.star(source('fake_source', 'orders')) }}
from {{ source('fake_source', 'orders') }}
-- this is the recommended usage from the dbt_utils readme
```

Result:

<img width="1151" alt="image" src="https://user-images.githubusercontent.com/73915542/189928840-fd6e1ebf-b9a3-4585-950f-ae03dc92480d.png">


This change should still be in line with our recommended DAG best practices -- this model will now only flag situations where there are multple distinct sources referenced in a single model. 

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md