### PR TITLE
add NULLIF to prevent dividing by 0 in fct_test_coverage

### DIFF
--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -32,6 +32,12 @@ models:
   dbt_project_evaluator_integration_tests:
     # materialize as ephemeral to prevent the fake models from executing, but keep them enabled
     +materialized: ephemeral
+  dbt_project_evaluator:
+    marts:
+      tests:
+        fct_test_coverage:
+          # materialize as a table to ensure SQL query runs successfully
+          +materialized: table
 
 tests:
   dbt_project_evaluator:
@@ -46,3 +52,7 @@ seeds:
   dbt_project_evaluator:
     dbt_project_evaluator_exceptions:
       +enabled: false
+
+vars:
+  # ensure integration tests run successfully when there are 0 of a given model type (extra)
+  model_types: ['staging', 'intermediate', 'marts', 'other', 'extra']

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -38,6 +38,10 @@ models:
         fct_test_coverage:
           # materialize as a table to ensure SQL query runs successfully
           +materialized: table
+      documentation:
+        fct_documentation_coverage:
+          # materialize as a table to ensure SQL query runs successfully
+          +materialized: table
 
 tests:
   dbt_project_evaluator:

--- a/models/marts/documentation/fct_documentation_coverage.sql
+++ b/models/marts/documentation/fct_documentation_coverage.sql
@@ -24,7 +24,7 @@ final as (
         sum(is_described_model) as documented_models,
         round(sum(is_described_model) * 100.0 / count(*), 2) as documentation_coverage_pct,
         {% for model_type in var('model_types') %}
-            round(sum(is_described_{{ model_type }}_model) * 100 / count(is_{{ model_type }}_model), 2) as {{ model_type }}_documentation_coverage_pct{% if not loop.last %},{% endif %}
+            round(sum(is_described_{{ model_type }}_model) * 100 / nullif(count(is_{{ model_type }}_model), 0), 2) as {{ model_type }}_documentation_coverage_pct{% if not loop.last %},{% endif %}
         {% endfor %}
 
     from models

--- a/models/marts/tests/fct_test_coverage.sql
+++ b/models/marts/tests/fct_test_coverage.sql
@@ -24,7 +24,7 @@ final as (
         sum(is_tested_model) as tested_models,
         round(sum(is_tested_model) * 100.0 / count(*), 2) as test_coverage_pct,
         {% for model_type in var('model_types') %}
-            round(sum(is_tested_{{ model_type }}_model) * 100.0 / count(is_{{ model_type }}_model), 2) as {{ model_type }}_test_coverage_pct,
+            round(sum(is_tested_{{ model_type }}_model) * 100.0 / nullif(count(is_{{ model_type }}_model), 2), 0) as {{ model_type }}_test_coverage_pct,
         {% endfor %}
         round(sum(number_of_tests_on_model) * 1.0 / count(*), 4) as test_to_model_ratio
 

--- a/models/marts/tests/fct_test_coverage.sql
+++ b/models/marts/tests/fct_test_coverage.sql
@@ -24,7 +24,7 @@ final as (
         sum(is_tested_model) as tested_models,
         round(sum(is_tested_model) * 100.0 / count(*), 2) as test_coverage_pct,
         {% for model_type in var('model_types') %}
-            round(sum(is_tested_{{ model_type }}_model) * 100.0 / nullif(count(is_{{ model_type }}_model), 2), 0) as {{ model_type }}_test_coverage_pct,
+            round(sum(is_tested_{{ model_type }}_model) * 100.0 / nullif(count(is_{{ model_type }}_model), 0), 2) as {{ model_type }}_test_coverage_pct,
         {% endfor %}
         round(sum(number_of_tests_on_model) * 1.0 / count(*), 4) as test_to_model_ratio
 


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->

Closes #202 

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

Adjusted calculation of `{{ model_type }}_test_coverage_pct` in `fct_test_coverage` to prevent dividing by 0 in the case of 0 models of a given type

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->
![Screen Shot 2022-09-14 at 4 08 06 PM](https://user-images.githubusercontent.com/53586774/190252122-11659580-eb87-4441-acb0-fe8b4ab8528b.png)

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md

Let me know if you have ideas as to how to catch this error in an integration test. `dbt build` was passing, but only when I went to actually query `fct_test_coverage` did I find this issue.