### PR TITLE
Dispatching macro filter_exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Change list column_names in select_from_values to column that can be … by @VasiliiSurov in https://github.com/dbt-labs/dbt-project-evaluator/pull/144
 * add metrics to int_direct_relationships by @graciegoheen in https://github.com/dbt-labs/dbt-project-evaluator/pull/159
 * add databricks CI step by @dave-connors-3 in https://github.com/dbt-labs/dbt-project-evaluator/pull/141
+* Dispatching the macro filter_exceptions in https://github.com/dbt-labs/dbt-project-evaluator/issues/212
 
 ## Fixes + Docs
 * Fix/add package name to dispatch by @graciegoheen in https://github.com/dbt-labs/dbt-project-evaluator/pull/124

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Change list column_names in select_from_values to column that can be … by @VasiliiSurov in https://github.com/dbt-labs/dbt-project-evaluator/pull/144
 * add metrics to int_direct_relationships by @graciegoheen in https://github.com/dbt-labs/dbt-project-evaluator/pull/159
 * add databricks CI step by @dave-connors-3 in https://github.com/dbt-labs/dbt-project-evaluator/pull/141
-* Dispatching the macro filter_exceptions in https://github.com/dbt-labs/dbt-project-evaluator/issues/212
+* Dispatching the macro filter_exceptions in https://github.com/dbt-labs/dbt-project-evaluator/pull/213
 
 ## Fixes + Docs
 * Fix/add package name to dispatch by @graciegoheen in https://github.com/dbt-labs/dbt-project-evaluator/pull/124

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Change list column_names in select_from_values to column that can be … by @VasiliiSurov in https://github.com/dbt-labs/dbt-project-evaluator/pull/144
 * add metrics to int_direct_relationships by @graciegoheen in https://github.com/dbt-labs/dbt-project-evaluator/pull/159
 * add databricks CI step by @dave-connors-3 in https://github.com/dbt-labs/dbt-project-evaluator/pull/141
-* Dispatching the macro filter_exceptions in https://github.com/dbt-labs/dbt-project-evaluator/pull/213
+* Dispatching the macro filter_exceptions by @larssnek in https://github.com/dbt-labs/dbt-project-evaluator/pull/213
 
 ## Fixes + Docs
 * Fix/add package name to dispatch by @graciegoheen in https://github.com/dbt-labs/dbt-project-evaluator/pull/124

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -60,8 +60,8 @@ vars:
   models_fanout_threshold: 3
 
   # -- Naming conventions variables --
-  # to add a new "layer", update the variable list_layers 
-  # and create new variables with the names <layer>_folder_name and/or <layer>_prefixes 
+  # to add a new "model type", update the variable model_types 
+  # and create new variables with the names <model_type>_folder_name and/or <model_type>_prefixes 
   model_types: ['staging', 'intermediate', 'marts', 'other']
 
   staging_folder_name: 'staging'

--- a/macros/filter_exceptions.sql
+++ b/macros/filter_exceptions.sql
@@ -1,9 +1,13 @@
-{% macro filter_exceptions(model_ref) %}
+{% macro filter_exceptions(model_ref) -%}
+  {{ return(adapter.dispatch('filter_exceptions', 'dbt_project_evaluator')(model_ref)) }}
+{%- endmacro %}
+
+{% macro default__filter_exceptions(model_ref) %}
 
 {% set query_filters %}
-select 
-    column_name, 
-    id_to_exclude 
+select
+    column_name,
+    id_to_exclude
 from {{ ref('dbt_project_evaluator_exceptions') }}
 where fct_name = '{{ model_ref.name }}'
 {% endset %}
@@ -14,5 +18,5 @@ where fct_name = '{{ model_ref.name }}'
         and {{ row_filter[0] }} not like '{{ row_filter[1] }}'
     {% endfor %}
 {% endif %}
-  
+
 {% endmacro %}


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes
- [x] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->
Closes #212 

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Dispatching the macro `filter_exceptions` in order to be able to override this macro in root projects

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md