### PR TITLE
added parent_model_type to fct_model_fanout

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,7 @@ Tests are assertions you make about your models and other resources in your dbt 
 
 <details>
 <summary><b>How to Remediate</b></summary>
+
 Apply a [uniqueness test](https://docs.getdbt.com/reference/resource-properties/tests#unique) and a [not null test](https://docs.getdbt.com/reference/resource-properties/tests#not_null) to the column that represents the grain of your model in its schema entry. For models that are unique across a combination of columns, we recommend adding a surrogate key column to your model, then applying these tests to that new model. See the [`surrogate_key`](https://github.com/dbt-labs/dbt-utils#surrogate_key-source) macro from dbt_utils for more info!
 
 Additional tests can be configured by applying a [generic test](https://docs.getdbt.com/docs/building-a-dbt-project/tests#generic-tests) in the model's `.yml` entry or by creating a [singular test](https://docs.getdbt.com/docs/building-a-dbt-project/tests#singular-tests) 
@@ -519,6 +520,7 @@ We recommend that every model in your dbt project has tests applied to ensure th
 
 <details>
 <summary><b>How to Remediate</b></summary>
+
 Apply a [generic test](https://docs.getdbt.com/docs/building-a-dbt-project/tests#generic-tests) in the model's `.yml` entry, or create a [singular test](https://docs.getdbt.com/docs/building-a-dbt-project/tests#singular-tests)
 in the `tests` directory of you project.
 
@@ -541,6 +543,7 @@ The documentation for your project includes model code, a DAG of your project, a
 
 <details>
 <summary><b>How to Remediate</b></summary>
+
 Apply a text [description](https://docs.getdbt.com/docs/building-a-dbt-project/documentation#related-documentation) in the model's `.yml` entry, or create a [docs block](https://docs.getdbt.com/docs/building-a-dbt-project/documentation#using-docs-blocks) in a markdown file, and use the `{{ doc() }}`
 function in the model's `.yml` entry.
 
@@ -558,6 +561,7 @@ The documentation for your project includes model code, a DAG of your project, a
 
 <details>
 <summary><b>How to Remediate</b></summary>
+
 Apply a text [description](https://docs.getdbt.com/docs/building-a-dbt-project/documentation) in the model's `.yml` entry, or create a [docs block](https://docs.getdbt.com/docs/building-a-dbt-project/documentation#using-docs-blocks) in a markdown file, and use the `{{ doc() }}`
 function in the model's `.yml` entry.
 

--- a/integration_tests/seeds/dag/dag_seeds.yml
+++ b/integration_tests/seeds/dag/dag_seeds.yml
@@ -50,6 +50,7 @@ seeds:
           compare_model: ref('fct_model_fanout')
           compare_columns:
             - parent
+            - parent_model_type
             - leaf_children
   
   - name: test_fct_staging_dependent_on_staging

--- a/integration_tests/seeds/dag/test_fct_model_fanout.csv
+++ b/integration_tests/seeds/dag/test_fct_model_fanout.csv
@@ -1,2 +1,2 @@
-﻿parent,leaf_children
-fct_model_6,"report_1, report_2, report_3"
+﻿parent,parent_model_type,leaf_children
+fct_model_6,marts,"report_1, report_2, report_3"


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes
- [x] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->
Closes #230 

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Added field `parent_model_type` to `fct_model_fanout` to allow users to write exceptions based off of the parent's model type. 

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->
<img width="924" alt="Screen Shot 2022-11-15 at 4 17 41 PM" src="https://user-images.githubusercontent.com/53586774/202036776-aba9aad9-d0cf-4ebd-94e8-1427f03cba53.png">

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)