### PR TITLE
make sure not to install dbt utils 1.0 in current version

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: [">=0.8.6", "<2.0.0"]
+    version: [">=0.8.6", "<1.0.0"]


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
Closes #243 


## Description & motivation

As it stands, when @joellabes releases dbtv1.0.0 next week, our package will import it based on the bounds in our `dbt_project.yml`, and it contains a breaking change. This PR lowers our bounds to ensure that we can maintain current functionality. This will need to be released today as a patch release, and we should notify the community that they should upgrade their projects immediately to ensure no breaks happen next week. 

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)