### PR TITLE
exclude custom test directory from check

### DIFF
--- a/integration_tests/seeds/tests/test_fct_missing_primary_key_tests.csv
+++ b/integration_tests/seeds/tests/test_fct_missing_primary_key_tests.csv
@@ -7,6 +7,6 @@ int_model_5,FALSE,0
 report_1,FALSE,0
 report_2,FALSE,0
 report_3,FALSE,0
-stg_model_1,FALSE,1
+stg_model_1,FALSE,2
 stg_model_3,FALSE,0
 stg_model_5,FALSE,0

--- a/integration_tests/seeds/tests/test_fct_test_coverage.csv
+++ b/integration_tests/seeds/tests/test_fct_test_coverage.csv
@@ -1,2 +1,2 @@
 ﻿total_models,total_tests,tested_models,test_coverage_pct,staging_test_coverage_pct,intermediate_test_coverage_pct,marts_test_coverage_pct,other_test_coverage_pct,test_to_model_ratio
-14,9,4,28.57,60.00,50.00,0.00,0.00,0.6429
+14,10,4,28.57,60.00,50.00,0.00,0.00,0.7143

--- a/integration_tests/tests/sample_custom_test.sql
+++ b/integration_tests/tests/sample_custom_test.sql
@@ -1,0 +1,2 @@
+select * from {{ ref('stg_model_1') }}
+where false

--- a/models/marts/core/int_all_graph_resources.sql
+++ b/models/marts/core/int_all_graph_resources.sql
@@ -44,6 +44,7 @@ joined as (
         unioned_with_calc.resource_type, 
         unioned_with_calc.file_path, 
         unioned_with_calc.directory_path,
+        unioned_with_calc.directory_path like 'models/%' as is_in_models_directory,
         unioned_with_calc.file_name,
         case 
             when unioned_with_calc.resource_type in ('test', 'source', 'metric', 'exposure', 'seed') then null

--- a/models/marts/structure/fct_test_directories.sql
+++ b/models/marts/structure/fct_test_directories.sql
@@ -48,7 +48,9 @@ test_file_paths as (
         file_name as test_yml_name,
         directory_path as test_yml_directory_path
     from resources
-    where resource_type = 'test'
+    where 
+        resource_type = 'test'
+        and is_in_models_directory
 
 ),
 


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
Closes #249 


## Description & motivation

This PR excludes tests not in the `models` directory from being checked by the `fct_test_directories` model. Custom tests are in the right place already!

## Integration Test Screenshot
<img width="909" alt="image" src="https://user-images.githubusercontent.com/73915542/205944058-c30f4a51-94aa-4ae7-8f10-b5e6fc1c5031.png">


## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)