### PR TITLE
Switch to new macro `dbt_utils.generate_surrogate_key`

### DIFF
--- a/models/marts/core/int_direct_relationships.sql
+++ b/models/marts/core/int_direct_relationships.sql
@@ -65,7 +65,7 @@ direct_relationships as (
 
 final as (
     select
-        {{ dbt_utils.surrogate_key(['resource_id', 'direct_parent_id']) }} as unique_id,
+        {{ dbt_utils.generate_surrogate_key(['resource_id', 'direct_parent_id']) }} as unique_id,
         *
     from direct_relationships
 )


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Description & motivation
When I run `dbt test`, I am seeing this error:
```
Compilation Error in model int_direct_relationships (models/marts/core/int_direct_relationships.sql)

  Warning: `dbt_utils.surrogate_key` has been replaced by `dbt_utils.generate_surrogate_key`. The new macro treats null values differently to empty strings. To restore the behaviour of the original macro, add a global variable in dbt_project.yml called `surrogate_key_treat_nulls_as_empty_strings` to your dbt_project.yml file with a value of True. The dbt_project_evaluator.int_direct_relationships model triggered this warning.

  > in macro default__surrogate_key (macros/sql/surrogate_key.sql)
  > called by macro surrogate_key (macros/sql/surrogate_key.sql)
  > called by model int_direct_relationships (models/marts/core/int_direct_relationships.sql)
```

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)