### PR TITLE
Remove `--pre` for DuckDB for testing

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 VENV="venv/bin/activate"
 
-if [[ ! -f $VENV ]]; then
+if [[ ! -f $VENV ]]
+then
     python3 -m venv venv
     . $VENV
 
     pip install --upgrade pip setuptools
-    pip install --pre "dbt-$1"
+
+    if [[ $1 == "duckdb" ]]
+    then
+        pip install "dbt-$1"
+    else
+        pip install --pre "dbt-$1"
+    fi
 fi
 
 . $VENV


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Slight update to the script to install the latest stable versions of `dbt-duckdb` and `duckdb` to avoid issues with CI checks sometimes breaking because of latest changes in the `pre` versions of `DuckDB`