### PR TITLE
Add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @graciegoheen @dave-connors-3 @b-per


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes
- [ ] new functionality

GitHub Quality of Live change

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

Set Grace, Dave and I as the code owners of the repo.
It means that we will automatically receive requests to review new PRs

Another option would be to create a GitHub team and set it as the owner of the repo but we currently don't have such a GH team.