### PR TITLE
🐛 Fix bug with 1.4 and `depends_on`

### DIFF
--- a/macros/unpack/get_nodes.sql
+++ b/macros/unpack/get_nodes.sql
@@ -25,7 +25,7 @@
                 "cast(" ~ dbt_project_evaluator.is_not_empty_string(node.description) | trim ~ " as boolean)",
                 "''" if not node.column_name else wrap_string_with_quotes(dbt.escape_single_quotes(node.column_name)),
                 wrap_string_with_quotes(node.meta | tojson),
-                wrap_string_with_quotes(node.depends_on.macros | tojson)
+                wrap_string_with_quotes(node.get('depends_on',{}).get('macros',[]) | tojson)
             ]
         %}
 

--- a/macros/unpack/get_relationships.sql
+++ b/macros/unpack/get_relationships.sql
@@ -19,7 +19,7 @@
 
         {%- for node in nodes_list -%}
 
-            {%- if node.depends_on.nodes|length == 0 -%}
+            {%- if node.get('depends_on',{}).get('nodes',[]) |length == 0 -%}
 
                 {%- set values_line = 
                   [
@@ -33,7 +33,7 @@
 
             {%- else -%}       
 
-                {%- for parent in node.depends_on.nodes -%}
+                {%- for parent in node.get('depends_on',{}).get('nodes',[]) -%}
 
                     {%- set values_line = 
                         [


### PR DESCRIPTION
In 1.4 `depends_on` does not exist for tests and seeds in the `graph`

This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Our CI has been failing since the release of dbt `1.4.0-b1`. Tests and Seeds no longer have a `depends_on` object in the `graph`. This branch fixes it by defaulting it to empty for those (it was empty for all of those before).

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)