### PR TITLE
clarify modeling layer assumptions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Each test warning indicates the presence of a type of misalignment. To troublesh
 3. Either fix the issue(s) or [customize](#customization) the package to exclude them
 
 #### Caveat Regarding Modeling Layer Assumptions
-This package assumes that you are using standard modeling layers (ie staging, intermediate, and marts) and that those layers are reflected in both the folder structure and naming prefixes used in your project. If you utilize these modeling layers but have prefixes other than `stg_`, `int_`, `fct_`, and `dim_`, you may override which prefixes the package should look for (see [Overriding Variables](#overriding-variables)). If your project doesn't use these modeling layers, you may wish to ignore or disable package models that don't apply in your case (ie [Downstream Models Dependent on Source](#downstream-models-dependent-on-source)).
+This package assumes that you are using standard modeling layers (ie staging, intermediate, and marts) and that those layers are reflected in both the folder structure and naming prefixes used in your project. If you utilize these modeling layers but have prefixes other than `stg_`, `int_`, `fct_`, and `dim_`, you may override which prefixes the package should look for (see Naming Convention Variables in [Overriding Variables](#overriding-variables)). If your project doesn't use these modeling layers, you may wish to ignore or disable package models that don't apply in your case (ie [Downstream Models Dependent on Source](#downstream-models-dependent-on-source)).
 
 ----
 ## Package Documentation

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ After refactoring your downstream model to select from the staging layer, your D
 `fct_marts_or_intermediate_dependent_on_source` ([source](models/marts/dag/fct_marts_or_intermediate_dependent_on_source.sql)) shows each downstream model (`marts` or `intermediate`)
 that depends directly on a source node.
 
-If you get no results or unexpected results, see [Modeling Layer Assumptions](#caveat-regarding-modeling-layer-assumptions) for more context.
+If this model returns no results, either your project doesn't contain any instances of this issue (hooray!) or you may need to update your [naming convention variables](#naming_convention_variables).
 
 <details>
 <summary><b>Example</b></summary>
@@ -393,7 +393,7 @@ After refactoring the above example, the DAG would look something like this:
 #### Staging Models Dependent on Downstream Models
 `fct_staging_dependent_on_marts_or_intermediate` ([source](models/marts/dag/fct_staging_dependent_on_marts_or_intermediate.sql)) shows each staging model that depends on an intermediate or marts model, as defined by the naming conventions and folder paths specified in your project variables.
 
-If you get no results or unexpected results, see [Modeling Layer Assumptions](#caveat-regarding-modeling-layer-assumptions) for more context.
+If this model returns no results, either your project doesn't contain any instances of this issue (hooray!) or you may need to update your [naming convention variables](#naming_convention_variables).
 
 <details>
 <summary><b>Example</b></summary>
@@ -426,7 +426,7 @@ After updating the model to use the appropriate `{{ source() }}` function, your 
 `fct_staging_dependent_on_staging` ([source](models/marts/dag/fct_staging_dependent_on_staging.sql)) shows each parent/child relationship where models in the staging layer are
 dependent on each other.
 
-If you get no results or unexpected results, see [Modeling Layer Assumptions](#caveat-regarding-modeling-layer-assumptions) for more context.
+If this model returns no results, either your project doesn't contain any instances of this issue (hooray!) or you may need to update your [naming convention variables](#naming_convention_variables).
 
 <details>
 <summary><b>Example</b></summary>
@@ -587,7 +587,7 @@ Tip: We recommend that every model in your dbt project has at minimum a model-le
 #### Model Naming Conventions
 `fct_model_naming_conventions` ([source](models/marts/structure/fct_model_naming_conventions.sql)) shows all cases where a model does NOT have the appropriate prefix.
 
-If you get no results or unexpected results, see [Modeling Layer Assumptions](#caveat-regarding-modeling-layer-assumptions) for more context.
+If this model returns no results, either your project doesn't contain any instances of this issue (hooray!) or you may need to update your [naming convention variables](#naming_convention_variables).
   
 <details>
 <summary><b>Example</b></summary>
@@ -628,7 +628,7 @@ For each model flagged, ensure the model type is defined and the model name is p
 - For staging models: The files should be nested in the staging folder of a subfolder that matches their source parent's name.
 - For non-staging models: The files should be nested closest to the folder name that matches their model type.
   
-If you get no results or unexpected results, see [Modeling Layer Assumptions](#caveat-regarding-modeling-layer-assumptions) for more context.
+If this model returns no results, either your project doesn't contain any instances of this issue (hooray!) or you may need to update your [naming convention variables](#naming_convention_variables).
 
 <details>
 <summary><b>Example</b></summary>
@@ -978,7 +978,7 @@ vars:
 | `marts_prefixes` | the list of acceptable prefixes for your marts models | fct_, dim_ |
 | `other_prefixes` | the list of acceptable prefixes for your other models | rpt_ |
 
-The `model_types`, `<model_type>_folder_name`, and `<model_type>_prefixes` variables allow the package to check if models in the different layers are in the correct folders and have a correct prefix in their name. The default model types are the ones we recommend in our [dbt Labs Style Guide](https://github.com/dbt-labs/corp/blob/main/dbt_style_guide.md). If your model types are different, you can update the `model_types` variable and create new variables for `<model_type>_folder_name` and/or `<model_type>_prefixes`.
+<a name="naming_convention_variables"></a>The `model_types`, `<model_type>_folder_name`, and `<model_type>_prefixes` variables allow the package to check if models in the different layers are in the correct folders and have a correct prefix in their name. The default model types are the ones we recommend in our [dbt Labs Style Guide](https://github.com/dbt-labs/corp/blob/main/dbt_style_guide.md). If your model types are different, you can update the `model_types` variable and create new variables for `<model_type>_folder_name` and/or `<model_type>_prefixes`.
 
 ```yml
 # dbt_project.yml

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Each test warning indicates the presence of a type of misalignment. To troublesh
 3. Either fix the issue(s) or [customize](#customization) the package to exclude them
 
 #### Caveat Regarding Modeling Layer Assumptions
-This package assumes that you are using dbt Labs' default modeling layers - staging, intermediate, marts, other.  These layers are reflected in both the folder structure and naming prefixes used in your project. To customize these modeling layers, see Naming Convention Variables in [Overriding Variables](#overriding-variables). If your project doesn't use our default modeling layers, you may wish to ignore or disable package models that don't apply in your case (i.e. [Downstream Models Dependent on Source](#downstream-models-dependent-on-source)).
+This package assumes that you are using dbt Labs' default modeling layers - staging, intermediate, marts, other. These layers are reflected in both the folder structure and naming prefixes used in your project. To customize these modeling layers, see Naming Convention Variables in [Overriding Variables](#overriding-variables). If your project doesn't use our default modeling layers, you may wish to ignore or disable package models that don't apply in your case (i.e. [Downstream Models Dependent on Source](#downstream-models-dependent-on-source)).
 
 ----
 ## Package Documentation

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Each test warning indicates the presence of a type of misalignment. To troublesh
 3. Either fix the issue(s) or [customize](#customization) the package to exclude them
 
 #### Caveat Regarding Modeling Layer Assumptions
-This package assumes that you are using standard modeling layers (ie staging, intermediate, and marts) and that those layers are reflected in both the folder structure and naming prefixes used in your project. If you utilize these modeling layers but have prefixes other than `stg_`, `int_`, `fct_`, and `dim_`, you may override which prefixes the package should look for (see Naming Convention Variables in [Overriding Variables](#overriding-variables)). If your project doesn't use these modeling layers, you may wish to ignore or disable package models that don't apply in your case (ie [Downstream Models Dependent on Source](#downstream-models-dependent-on-source)).
+This package assumes that you are using dbt Labs' default modeling layers - staging, intermediate, marts, other.  These layers are reflected in both the folder structure and naming prefixes used in your project. To customize these modeling layers, see Naming Convention Variables in [Overriding Variables](#overriding-variables). If your project doesn't use our default modeling layers, you may wish to ignore or disable package models that don't apply in your case (i.e. [Downstream Models Dependent on Source](#downstream-models-dependent-on-source)).
 
 ----
 ## Package Documentation

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ After refactoring your downstream model to select from the staging layer, your D
 `fct_marts_or_intermediate_dependent_on_source` ([source](models/marts/dag/fct_marts_or_intermediate_dependent_on_source.sql)) shows each downstream model (`marts` or `intermediate`)
 that depends directly on a source node.
 
+Note: if your naming conventions don't **correlate to modeling layer** (ie `stg`, `int`, `fct`, etc. or another custom naming pattern defined in the [Overriding Variables](#overriding-variables) section below), this check will return no results.
+
 <details>
 <summary><b>Example</b></summary>
 
@@ -388,6 +390,8 @@ After refactoring the above example, the DAG would look something like this:
 #### Staging Models Dependent on Downstream Models
 `fct_staging_dependent_on_marts_or_intermediate` ([source](models/marts/dag/fct_staging_dependent_on_marts_or_intermediate.sql)) shows each staging model that depends on an intermediate or marts model, as defined by the naming conventions and folder paths specified in your project variables.
 
+Note: if your naming conventions don't **correlate to modeling layer** (ie `stg`, `int`, `fct`, etc. or another custom naming pattern defined in the [Overriding Variables](#overriding-variables) section below), this check will return no results.
+
 <details>
 <summary><b>Example</b></summary>
 
@@ -418,6 +422,8 @@ After updating the model to use the appropriate `{{ source() }}` function, your 
 #### Staging Models Dependent on Other Staging Models
 `fct_staging_dependent_on_staging` ([source](models/marts/dag/fct_staging_dependent_on_staging.sql)) shows each parent/child relationship where models in the staging layer are
 dependent on each other.
+
+Note: if your naming conventions don't **correlate to modeling layer** (ie `stg`, `int`, `fct`, etc. or another custom naming pattern defined in the [Overriding Variables](#overriding-variables) section below), this check will return no results.
 
 <details>
 <summary><b>Example</b></summary>
@@ -578,6 +584,8 @@ Tip: We recommend that every model in your dbt project has at minimum a model-le
 #### Model Naming Conventions
 `fct_model_naming_conventions` ([source](models/marts/structure/fct_model_naming_conventions.sql)) shows all cases where a model does NOT have the appropriate prefix.
 
+Note: if your naming conventions don't **correlate to modeling layer** (ie `stg`, `int`, `fct`, etc. or another custom naming pattern defined in the [Overriding Variables](#overriding-variables) section below), this check will return no results.
+  
 <details>
 <summary><b>Example</b></summary>
 
@@ -615,7 +623,9 @@ For each model flagged, ensure the model type is defined and the model name is p
 
 `fct_model_directories` ([source](models/marts/structure/fct_model_directories.sql)) shows all cases where a model is NOT in the appropriate subdirectory:
 - For staging models: The files should be nested in the staging folder of a subfolder that matches their source parent's name.
-- For non-staging models: The files should be nested closest to the folder name that matches their model type.  
+- For non-staging models: The files should be nested closest to the folder name that matches their model type.
+  
+Note: if your naming conventions don't **correlate to modeling layer** (ie `stg`, `int`, `fct`, etc. or another custom naming pattern defined in the [Overriding Variables](#overriding-variables) section below), this check will return no results.
 
 <details>
 <summary><b>Example</b></summary>

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Each test warning indicates the presence of a type of misalignment. To troublesh
 2. Query the associated model to find the specific instances of the issue within your project
 3. Either fix the issue(s) or [customize](#customization) the package to exclude them
 
+#### Caveat Regarding Modeling Layer Assumptions
+This package assumes that you are using standard modeling layers (ie staging, intermediate, and marts) and that those layers are reflected in both the folder structure and naming prefixes used in your project. If you utilize these modeling layers but have prefixes other than `stg_`, `int_`, `fct_`, and `dim_`, you may override which prefixes the package should look for (see [Overriding Variables](#overriding-variables)). If your project doesn't use these modeling layers, you may wish to ignore or disable package models that don't apply in your case (ie [Downstream Models Dependent on Source](#downstream-models-dependent-on-source)).
+
 ----
 ## Package Documentation
 
@@ -137,7 +140,7 @@ After refactoring your downstream model to select from the staging layer, your D
 `fct_marts_or_intermediate_dependent_on_source` ([source](models/marts/dag/fct_marts_or_intermediate_dependent_on_source.sql)) shows each downstream model (`marts` or `intermediate`)
 that depends directly on a source node.
 
-Note: if your naming conventions don't **correlate to modeling layer** (ie `stg`, `int`, `fct`, etc. or another custom naming pattern defined in the [Overriding Variables](#overriding-variables) section below), this check will return no results.
+If you get no results or unexpected results, see [Modeling Layer Assumptions](#caveat-regarding-modeling-layer-assumptions) for more context.
 
 <details>
 <summary><b>Example</b></summary>
@@ -390,7 +393,7 @@ After refactoring the above example, the DAG would look something like this:
 #### Staging Models Dependent on Downstream Models
 `fct_staging_dependent_on_marts_or_intermediate` ([source](models/marts/dag/fct_staging_dependent_on_marts_or_intermediate.sql)) shows each staging model that depends on an intermediate or marts model, as defined by the naming conventions and folder paths specified in your project variables.
 
-Note: if your naming conventions don't **correlate to modeling layer** (ie `stg`, `int`, `fct`, etc. or another custom naming pattern defined in the [Overriding Variables](#overriding-variables) section below), this check will return no results.
+If you get no results or unexpected results, see [Modeling Layer Assumptions](#caveat-regarding-modeling-layer-assumptions) for more context.
 
 <details>
 <summary><b>Example</b></summary>
@@ -423,7 +426,7 @@ After updating the model to use the appropriate `{{ source() }}` function, your 
 `fct_staging_dependent_on_staging` ([source](models/marts/dag/fct_staging_dependent_on_staging.sql)) shows each parent/child relationship where models in the staging layer are
 dependent on each other.
 
-Note: if your naming conventions don't **correlate to modeling layer** (ie `stg`, `int`, `fct`, etc. or another custom naming pattern defined in the [Overriding Variables](#overriding-variables) section below), this check will return no results.
+If you get no results or unexpected results, see [Modeling Layer Assumptions](#caveat-regarding-modeling-layer-assumptions) for more context.
 
 <details>
 <summary><b>Example</b></summary>
@@ -584,7 +587,7 @@ Tip: We recommend that every model in your dbt project has at minimum a model-le
 #### Model Naming Conventions
 `fct_model_naming_conventions` ([source](models/marts/structure/fct_model_naming_conventions.sql)) shows all cases where a model does NOT have the appropriate prefix.
 
-Note: if your naming conventions don't **correlate to modeling layer** (ie `stg`, `int`, `fct`, etc. or another custom naming pattern defined in the [Overriding Variables](#overriding-variables) section below), this check will return no results.
+If you get no results or unexpected results, see [Modeling Layer Assumptions](#caveat-regarding-modeling-layer-assumptions) for more context.
   
 <details>
 <summary><b>Example</b></summary>
@@ -625,7 +628,7 @@ For each model flagged, ensure the model type is defined and the model name is p
 - For staging models: The files should be nested in the staging folder of a subfolder that matches their source parent's name.
 - For non-staging models: The files should be nested closest to the folder name that matches their model type.
   
-Note: if your naming conventions don't **correlate to modeling layer** (ie `stg`, `int`, `fct`, etc. or another custom naming pattern defined in the [Overriding Variables](#overriding-variables) section below), this check will return no results.
+If you get no results or unexpected results, see [Modeling Layer Assumptions](#caveat-regarding-modeling-layer-assumptions) for more context.
 
 <details>
 <summary><b>Example</b></summary>


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes
- [X] new functionality

## Link to Issue 
This addresses open issue #241.


## Description & motivation
This PR updates the README to clarify the assumption that resources are named by modeling layer (whether conforming exactly to dbt Labs' style guide or not) and explicitly acknowledges limitations in these checks if resources are named using another categorization method.

## Integration Test Screenshot
N/A

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
- [X] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)