### PR TITLE
Add friendlier name to range tests

### DIFF
--- a/models/marts/documentation/documentation.yml
+++ b/models/marts/documentation/documentation.yml
@@ -10,6 +10,7 @@ models:
         description: the number of models in the project with a description divided by the total number of models in the project
         tests:
           - dbt_utils.accepted_range:
+              name: valid_documentation_coverage
               min_value: "{{ var('documentation_coverage_target') }}"
               severity: warn
   - name: fct_undocumented_models

--- a/models/marts/performance/performance.yml
+++ b/models/marts/performance/performance.yml
@@ -10,6 +10,7 @@ models:
       - name: distance
         tests:
           - dbt_utils.accepted_range:
+              name: valid_chained_views_dependencies
               max_value: "{{ var('chained_views_threshold') }}"
               inclusive: false
               severity: warn

--- a/models/marts/tests/testing.yml
+++ b/models/marts/tests/testing.yml
@@ -14,6 +14,7 @@ models:
         description: the number of models in the project with at least one test configured divided by the total number of models in the project
         tests:
           - dbt_utils.accepted_range:
+              name: valid_test_coverage
               min_value: "{{ var('test_coverage_target') }}"
               severity: warn
   - name: fct_missing_primary_key_tests


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes
- [ ] new functionality
- [X] little quality tweak

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

Just renaming some tests that had a very long name showing in the logs. The `is_empty` are OK but the `range` were very long.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [x] DuckDB
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)