### PR TITLE
check if seed exists in warehouse before filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1107,7 +1107,7 @@ which looks like the following when loaded in the warehouse
 
 #### 2. Deactivate the seed from the original package
 
-Only a single seed can exist with a given name. When using a custom one, we need to deactivate the one from the package by adding the following to our `dbt_project.yml`
+Only a single seed can exist with a given name. When using a custom one, we need to deactivate the blank one from the package by adding the following to our `dbt_project.yml`
 ```yml
 # dbt_project.yml
 

--- a/macros/filter_exceptions.sql
+++ b/macros/filter_exceptions.sql
@@ -4,9 +4,13 @@
 
 {% macro default__filter_exceptions(model_ref) %}
 
-    {% set seed_exists = load_relation(ref('dbt_project_evaluator_exceptions')) is not none %}
+    {% if execute %}
+    {% set is_custom_seed = graph.nodes.values() | 
+            selectattr('resource_type', 'equalto', 'seed') | 
+            selectattr('name', 'equalto', 'dbt_project_evaluator_exceptions') | 
+            selectattr('package_name', 'equalto', 'dbt_project_evaluator') is none %}
 
-    {% if seed_exists %}
+    {% if is_custom_seed %}
 
         {% set query_filters %}
         select
@@ -23,6 +27,8 @@
             {% endfor %}
         {% endif %}
     
+    {% endif %}
+
     {% endif %}
 
 {% endmacro %}

--- a/macros/filter_exceptions.sql
+++ b/macros/filter_exceptions.sql
@@ -20,7 +20,7 @@
 
     {% if not is_default_seed %}
     
-        {% if execute and flags.WHICH not in ['compile'] %}
+        {% if flags.WHICH not in ['compile'] %}
             where 1 = 1
             {% for row_filter in run_query(query_filters) %}
                 and {{ row_filter[0] }} not like '{{ row_filter[1] }}'

--- a/macros/filter_exceptions.sql
+++ b/macros/filter_exceptions.sql
@@ -1,22 +1,28 @@
 {% macro filter_exceptions(model_ref) -%}
-  {{ return(adapter.dispatch('filter_exceptions', 'dbt_project_evaluator')(model_ref)) }}
+    {{ return(adapter.dispatch('filter_exceptions', 'dbt_project_evaluator')(model_ref)) }}
 {%- endmacro %}
 
 {% macro default__filter_exceptions(model_ref) %}
 
-{% set query_filters %}
-select
-    column_name,
-    id_to_exclude
-from {{ ref('dbt_project_evaluator_exceptions') }}
-where fct_name = '{{ model_ref.name }}'
-{% endset %}
+    {% set seed_exists = load_relation(ref('dbt_project_evaluator_exceptions')) is not none %}
 
-{% if execute and flags.WHICH not in ['compile'] %}
-    where 1 = 1
-    {% for row_filter in run_query(query_filters) %}
-        and {{ row_filter[0] }} not like '{{ row_filter[1] }}'
-    {% endfor %}
-{% endif %}
+    {% if seed_exists %}
+
+        {% set query_filters %}
+        select
+            column_name,
+            id_to_exclude
+        from {{ ref('dbt_project_evaluator_exceptions') }}
+        where fct_name = '{{ model_ref.name }}'
+        {% endset %}
+    
+        {% if execute and flags.WHICH not in ['compile'] %}
+            where 1 = 1
+            {% for row_filter in run_query(query_filters) %}
+                and {{ row_filter[0] }} not like '{{ row_filter[1] }}'
+            {% endfor %}
+        {% endif %}
+    
+    {% endif %}
 
 {% endmacro %}


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->
Closes #225 

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Our readme suggests executing a `dbt build` of this package, which works properly. If users instead execute a `dbt run` on this package, it will fail as the blank seed necessary for the filtering exceptions functionality does not yet exist in their warehouse. 

I added a check to the filter_exceptions macro to first check if the seed exists in the warehouse, and if it doesn't, don't do any filtering.

Note: We still have to have the blank seed file in our project as the default, because otherwise this check will return a compilation error as the `dbt_project_evaluator_exceptions` would not be a node in the project..

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)