### PR TITLE
Escape single quotes in metric labels in get_metrics()

### DIFF
--- a/integration_tests/models/marts/metrics.yml
+++ b/integration_tests/models/marts/metrics.yml
@@ -2,7 +2,7 @@ version: 2
 
 metrics:
   - name: new_customers
-    label: New Customers
+    label: New Customers marked 'paying'
     model: ref('dim_model_7')
     description: "The number of paid customers using the product"
 

--- a/integration_tests/models/marts/metrics.yml
+++ b/integration_tests/models/marts/metrics.yml
@@ -26,4 +26,3 @@ metrics:
 
     meta: 
       team: "Finance"
-      refresh_rate: "Bob's weekly run"

--- a/integration_tests/models/marts/metrics.yml
+++ b/integration_tests/models/marts/metrics.yml
@@ -26,3 +26,4 @@ metrics:
 
     meta: 
       team: "Finance"
+      refresh_rate: "Bob's weekly run"

--- a/macros/unpack/get_metrics.sql
+++ b/macros/unpack/get_metrics.sql
@@ -30,7 +30,7 @@
             "cast(" ~ dbt_project_evaluator.is_not_empty_string(node.description) | trim ~ " as boolean)",
             wrap_string_with_quotes(node.type),
             wrap_string_with_quotes(node.model.identifier),
-            wrap_string_with_quotes(dbt.escape_single_quotes(node.label))
+            wrap_string_with_quotes(dbt.escape_single_quotes(node.label)),
             wrap_string_with_quotes(node.sql),
             wrap_string_with_quotes(node.timestamp),
             wrap_string_with_quotes(node.package_name),

--- a/macros/unpack/get_metrics.sql
+++ b/macros/unpack/get_metrics.sql
@@ -22,7 +22,7 @@
           {% endset %}
           
           {% set label %}
-          {{ dbt.escape_single_quote(node.label) }}
+          {{ dbt.escape_single_quotes(node.label) }}
           {% endset %}
           
           {%- set values_line = 

--- a/macros/unpack/get_metrics.sql
+++ b/macros/unpack/get_metrics.sql
@@ -20,6 +20,7 @@
                 ''
             {% endif -%}
           {% endset %}
+          
           {%- set values_line = 
             [
             wrap_string_with_quotes(node.unique_id),

--- a/macros/unpack/get_metrics.sql
+++ b/macros/unpack/get_metrics.sql
@@ -34,7 +34,7 @@
             "cast(" ~ dbt_project_evaluator.is_not_empty_string(node.description) | trim ~ " as boolean)",
             wrap_string_with_quotes(node.type),
             wrap_string_with_quotes(node.model.identifier),
-            wrap_string_with_quotes(label),
+            wrap_string_with_quotes(dbt.escape_single_quotes(node.label))
             wrap_string_with_quotes(node.sql),
             wrap_string_with_quotes(node.timestamp),
             wrap_string_with_quotes(node.package_name),

--- a/macros/unpack/get_metrics.sql
+++ b/macros/unpack/get_metrics.sql
@@ -21,10 +21,6 @@
             {% endif -%}
           {% endset %}
           
-          {% set label %}
-          {{ dbt.escape_single_quotes(node.label) }}
-          {% endset %}
-          
           {%- set values_line = 
             [
             wrap_string_with_quotes(node.unique_id),

--- a/macros/unpack/get_metrics.sql
+++ b/macros/unpack/get_metrics.sql
@@ -20,7 +20,6 @@
                 ''
             {% endif -%}
           {% endset %}
-          
           {%- set values_line = 
             [
             wrap_string_with_quotes(node.unique_id),

--- a/macros/unpack/get_metrics.sql
+++ b/macros/unpack/get_metrics.sql
@@ -20,7 +20,11 @@
                 ''
             {% endif -%}
           {% endset %}
-
+          
+          {% set label %}
+          {{ dbt.escape_single_quote(node.label) }}
+          {% endset %}
+          
           {%- set values_line = 
             [
             wrap_string_with_quotes(node.unique_id),
@@ -30,7 +34,7 @@
             "cast(" ~ dbt_project_evaluator.is_not_empty_string(node.description) | trim ~ " as boolean)",
             wrap_string_with_quotes(node.type),
             wrap_string_with_quotes(node.model.identifier),
-            wrap_string_with_quotes(node.label),
+            wrap_string_with_quotes(label),
             wrap_string_with_quotes(node.sql),
             wrap_string_with_quotes(node.timestamp),
             wrap_string_with_quotes(node.package_name),


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
https://github.com/dbt-labs/dbt-project-evaluator/issues/278


## Description & motivation
As discussed in the issue, currently the `get_metrics` macro can't handle single quotes in the label of a metric, causing a failure when building `stg_metrics`. This code adds a statement which sets `label` to be the single-quote escaped version of the label, and then passes that to the `wrap_string_with_quotes` function instead.

## Integration Test Screenshot
![image](https://user-images.githubusercontent.com/65237851/211035362-48da0ff4-c2c4-410a-bae0-62e2bed19cb2.png)

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)