### PR TITLE
remove suffix instead of trimming prefix

### DIFF
--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -59,6 +59,8 @@ seeds:
 
 vars:
   # ensure integration tests run successfully when there are 0 of a given model type (extra)
-  model_types: ['staging', 'intermediate', 'marts', 'other', 'extra']
+  model_types: ['staging', 'intermediate', 'marts', 'other', 'extra', 'new_model_type']
   # dummy variable used for testing fct_hard_coded_references
   my_table_reference: 'grace_table'
+  new_model_type_folder_name: 'my_new_models'
+  new_model_type_prefixes: 'nwmdl_'

--- a/integration_tests/models/dbt_project_evaluator_schema_tests/graph.yml
+++ b/integration_tests/models/dbt_project_evaluator_schema_tests/graph.yml
@@ -64,6 +64,10 @@ models:
         tests:
           - unique
           - not_null
+      - name: model_type 
+        tests:
+          - accepted_values:
+              values: "{{ var('model_types') }}"
 
   - name: stg_naming_convention_prefixes
     description: "This table shows one record for each accepted model prefix for each model type (staging, intermediate, marts) from the provided variables"
@@ -73,3 +77,7 @@ models:
         tests:
           - unique
           - not_null
+      - name: model_type 
+        tests:
+          - accepted_values:
+              values: "{{ var('model_types') }}"

--- a/models/staging/variables/stg_naming_convention_folders.sql
+++ b/models/staging/variables/stg_naming_convention_folders.sql
@@ -1,10 +1,10 @@
 {% set var_model_types = var('model_types') %}
-{% set suffix_model_type = '_folder_name' %}
+{% set suffix_folder = '_folder_name' %}
 
 {% set vars_folders = [] %}
 
 {% for model_type in var_model_types %}
-  {% do vars_folders.append(model_type ~ suffix_model_type) %}
+  {% do vars_folders.append(model_type ~ suffix_folder) %}
 {% endfor %}
 
 with vars_folders_table as (
@@ -13,6 +13,6 @@ with vars_folders_table as (
 
 select
     var_name as folder_name, 
-    {{ dbt.split_part('var_name', "'_'", 1) }} as model_type,
+    {{ dbt.replace('var_name', wrap_string_with_quotes(suffix_folder), "''") }} as model_type,
     var_value as folder_name_value
 from vars_folders_table

--- a/models/staging/variables/stg_naming_convention_prefixes.sql
+++ b/models/staging/variables/stg_naming_convention_prefixes.sql
@@ -15,7 +15,7 @@ parsed as (
 
 select
     var_name as prefix_name, 
-    {{ dbt.split_part('var_name', "'_'", 1) }} as model_type,
+    {{ dbt.replace('var_name', wrap_string_with_quotes(suffix_model_type) , "''") }} as model_type,
     var_value as prefix_value
 from vars_prefix_table
 


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
closes #283 

## Description & motivation

Allows for users to have model types that contain underscores. 

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)