### PR TITLE
add recursion limit

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -78,8 +78,8 @@ vars:
 
   # -- Performance variables --
   chained_views_threshold: 5
+
+  # -- Execution variables --
   insert_batch_size: "{{ 500 if target.type == 'bigquery' else 10000 }}"
   generate_all_dag_paths: true
-
-  # -- Warehouse specific variables --
   max_depth_dag: 9

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -79,6 +79,7 @@ vars:
   # -- Performance variables --
   chained_views_threshold: 5
   insert_batch_size: "{{ 500 if target.type == 'bigquery' else 10000 }}"
+  generate_all_dag_paths: true
 
   # -- Warehouse specific variables --
   max_depth_dag: 9

--- a/integration_tests_2/dbt_project.yml
+++ b/integration_tests_2/dbt_project.yml
@@ -34,3 +34,7 @@ models:
   dbt_project_evaluator_integration_tests_2:
     # materialize as ephemeral to prevent the fake models from executing, but keep them enabled
     +materialized: ephemeral
+
+vars:
+  generate_all_dag_paths: false
+  max_depth_dag: 5

--- a/macros/recursive_dag.sql
+++ b/macros/recursive_dag.sql
@@ -100,6 +100,17 @@ all_relationships (
     from direct_relationships
     inner join all_relationships
         on all_relationships.child_id = direct_relationships.direct_parent_id
+
+    {% if not var('generate_all_dag_paths') %}
+        {% if var('max_depth_dag') < 2 or var('max_depth_dag') < var('chained_views_threshold')%}
+            {% do exceptions.raise_compiler_error(
+                'Variable max_depth_dag must be at least 2 and must be greater than chained_views_threshold.'
+                ) %}
+        {% else %}
+        where distance <= {{ var('max_depth_dag')}}
+        {% endif %}
+    {% endif %}
+
 )
 
 {% endmacro %}
@@ -108,7 +119,7 @@ all_relationships (
 {% macro bigquery__recursive_dag() %}
 
 -- as of Feb 2022 BigQuery doesn't support with recursive in the same way as other DWs
-{% set max_depth = var('max_depth_dag',9) %}
+{% set max_depth = var('max_depth_dag') %}
 
 with direct_relationships as (
     select  


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [x] new functionality

## Link to Issue 

closes #288 

## Description & motivation

This gives non-BQ and Spark users a way to reduce the recursion in `int_all_dag_relationships`, which was causing issues for massive projects (11k nodes) per Josh Devlin in the community


## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [x] DuckDB
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)