### PR TITLE
add `distinct` back to relationships staging models

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -82,3 +82,8 @@ vars:
 
   # -- Warehouse specific variables --
   max_depth_dag: 9
+
+
+dispatch:
+  - macro_namespace: dbt_utils
+    search_order: ['dbt_project_evaluator', 'dbt_utils']

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -27,7 +27,9 @@ clean-targets:         # directories to be removed by `dbt clean`
 dispatch:
   - macro_namespace: dbt
     search_order: ['dbt_project_evaluator', 'dbt']
-
+  - macro_namespace: dbt_utils
+    search_order: ['dbt_project_evaluator', 'dbt_utils']
+    
 models:
   dbt_project_evaluator_integration_tests:
     # materialize as ephemeral to prevent the fake models from executing, but keep them enabled

--- a/integration_tests/models/staging/stg_model_4.sql
+++ b/integration_tests/models/staging/stg_model_4.sql
@@ -1,3 +1,4 @@
 -- depends on: {{ ref('stg_model_2') }}
+-- depends on: {{ ref('stg_model_2') }}
 
 select 1 as id

--- a/integration_tests_2/dbt_project.yml
+++ b/integration_tests_2/dbt_project.yml
@@ -27,6 +27,8 @@ clean-targets:         # directories to be removed by `dbt clean`
 dispatch:
   - macro_namespace: dbt
     search_order: ['dbt_project_evaluator', 'dbt']
+  - macro_namespace: dbt_utils
+    search_order: ['dbt_project_evaluator', 'dbt_utils']
 
 on-run-end: "{{ dbt_project_evaluator.print_dbt_project_evaluator_issues() }}"
 

--- a/macros/cross_db_shim/duckdb_shims.sql
+++ b/macros/cross_db_shim/duckdb_shims.sql
@@ -25,3 +25,9 @@
         )
 
 {%- endmacro %}
+
+{% macro duckdb__deduplicate(relation, partition_by, order_by) -%}
+
+    {{ return(dbt_utils.snowflake__deduplicate(relation, partition_by, order_by=order_by)) }}
+
+{% endmacro %}

--- a/models/staging/graph/stg_exposure_relationships.sql
+++ b/models/staging/graph/stg_exposure_relationships.sql
@@ -11,4 +11,10 @@ final as (
     from _base_exposure_relationships
 )
 
-select distinct * from final
+{{
+    dbt_utils.deduplicate(
+        relation='final',
+        partition_by='unique_id',
+        order_by='is_primary_relationship desc'
+    )
+}}

--- a/models/staging/graph/stg_metric_relationships.sql
+++ b/models/staging/graph/stg_metric_relationships.sql
@@ -11,4 +11,4 @@ final as (
     from _base_metric_relationships
 )
 
-select * from final
+select distinct * from final

--- a/models/staging/graph/stg_metric_relationships.sql
+++ b/models/staging/graph/stg_metric_relationships.sql
@@ -11,4 +11,10 @@ final as (
     from _base_metric_relationships
 )
 
-select distinct * from final
+{{
+    dbt_utils.deduplicate(
+        relation='final',
+        partition_by='unique_id',
+        order_by='is_primary_relationship desc'
+    )
+}}

--- a/models/staging/graph/stg_node_relationships.sql
+++ b/models/staging/graph/stg_node_relationships.sql
@@ -11,4 +11,10 @@ final as (
     from _base_node_relationships
 )
 
-select distinct * from final
+{{
+    dbt_utils.deduplicate(
+        relation='final',
+        partition_by='unique_id',
+        order_by='is_primary_relationship desc'
+    )
+}}

--- a/models/staging/graph/stg_node_relationships.sql
+++ b/models/staging/graph/stg_node_relationships.sql
@@ -11,4 +11,4 @@ final as (
     from _base_node_relationships
 )
 
-select  * from final
+select distinct * from final


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->


## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
The staging relationships models cannot have any duplicates otherwise it can lead to fanout in the downstream int_all_dag_relationships model. Adding a `distinct` back to the relevant staging relationships model

Note: Open to suggestions as to how to improve our integration tests here. There is already uniqueness checks for the `unique_id` of these models in integration_tests/models/dbt_project_evaluator_schema_tests/graph.yml

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)