### PR TITLE
Allow override of `model_type` determination preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1034,6 +1034,7 @@ vars:
 | `intermediate_prefixes` | the list of acceptable prefixes for your intermediate models | int_ |
 | `marts_prefixes` | the list of acceptable prefixes for your marts models | fct_, dim_ |
 | `other_prefixes` | the list of acceptable prefixes for your other models | rpt_ |
+| `prefer_model_folder_type_to_prefix` | override to prefer the use of the folder name to the prefix when determining model type | false |
 
 The `model_types`, `<model_type>_folder_name`, and `<model_type>_prefixes` variables allow the package to check if models in the different layers are in the correct folders and have a correct prefix in their name. The default model types are the ones we recommend in our [dbt Labs Style Guide](https://github.com/dbt-labs/corp/blob/main/dbt_style_guide.md). If your model types are different, you can update the `model_types` variable and create new variables for `<model_type>_folder_name` and/or `<model_type>_prefixes`.
 
@@ -1047,6 +1048,8 @@ vars:
     util_folder_name: 'util'
     util_prefixes: ['util_']
 ```
+
+By default, we use the `<model_type>_prefixes` to determine the `model_type` where the prefix and folder name types differ, however you can set the `prefer_model_folder_type_to_prefix` to `true` to change this behaviour to take the type determined by the folder name in preference.
 </details>
 
 <details>

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -82,3 +82,6 @@ vars:
 
   # -- Warehouse specific variables --
   max_depth_dag: 9
+
+  # -- Model type preference --
+  prefer_model_folder_type_to_prefix: false

--- a/models/marts/core/int_all_graph_resources.sql
+++ b/models/marts/core/int_all_graph_resources.sql
@@ -109,8 +109,13 @@ calculate_model_type as (
         *, 
         case 
             when resource_type in ('test', 'source', 'metric', 'exposure', 'seed') then null
-            -- by default we will define the model type based on its prefix in the case prefix and folder types are different
-            else coalesce(model_type_prefix, model_type_folder, 'other') 
+            /* use the prefer_model_folder_type_to_prefix variable to determine whether to take the prefix or
+            folder in preference in the case when they are differen */ 
+            else 
+                case
+                    when {{ var('prefer_model_folder_type_to_prefix') }} then coalesce(model_type_folder, model_type_prefix, 'other')
+                    else coalesce(model_type_prefix, model_type_folder, 'other')
+                end
         end as model_type,
         row_number() over (partition by resource_id order by position_folder desc) as folder_name_rank
     from joined

--- a/models/marts/core/int_all_graph_resources.sql
+++ b/models/marts/core/int_all_graph_resources.sql
@@ -109,13 +109,14 @@ calculate_model_type as (
         *, 
         case 
             when resource_type in ('test', 'source', 'metric', 'exposure', 'seed') then null
-            /* use the prefer_model_folder_type_to_prefix variable to determine whether to take the prefix or
-            folder in preference in the case when they are differen */ 
             else 
-                case
-                    when {{ var('prefer_model_folder_type_to_prefix') }} then coalesce(model_type_folder, model_type_prefix, 'other')
-                    else coalesce(model_type_prefix, model_type_folder, 'other')
-                end
+                {% if var('prefer_model_folder_type_to_prefix') -%}
+                    -- default behaviour overriden to define the model type based on its folder in the case prefix and folder types are different
+                    coalesce(model_type_folder, model_type_prefix, 'other')
+                {%- else -%}
+                    -- by default we will define the model type based on its prefix in the case prefix and folder types are different
+                    coalesce(model_type_prefix, model_type_folder, 'other')
+                {%- endif %}
         end as model_type,
         row_number() over (partition by resource_id order by position_folder desc) as folder_name_rank
     from joined


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes
- [x] new functionality

## Link to Issue 
Closes #286 

## Description & motivation
This allows users to override the default behaviour that uses the model prefix to determine the model type, in preference to the model folder.

## Integration Test Screenshot
I am unsure how to run this.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)

I am unsure how to add tests to this as it isn't a new test, but changing the default behaviour. I have verified locally that changing the variable changes the compiled SQL:

** Default behaviour**

```yml
# dbt_project.yml
vars:
  prefer_model_folder_type_to_prefix: false
```

```sql
# target/compiled/dbt_project_evaluator/models/marts/core/int_all_graph_resources.sql
...
        case 
            when resource_type in ('test', 'source', 'metric', 'exposure', 'seed') then null
            else 
                -- by default we will define the model type based on its prefix in the case prefix and folder types are different
                    coalesce(model_type_prefix, model_type_folder, 'other')
        end as model_type,
...
```

**Overridden behaviour**

```yml
# dbt_project.yml
vars:
  prefer_model_folder_type_to_prefix: true
```

```sql
# target/compiled/dbt_project_evaluator/models/marts/core/int_all_graph_resources.sql
...
        case 
            when resource_type in ('test', 'source', 'metric', 'exposure', 'seed') then null
            else 
                -- default behaviour overriden to define the model type based on its folder in the case prefix and folder types are different
                    coalesce(model_type_folder, model_type_prefix, 'other')
        end as model_type,
...
```

