### PR TITLE
Update int_all_graph_resources.sql

### DIFF
--- a/models/marts/core/int_all_graph_resources.sql
+++ b/models/marts/core/int_all_graph_resources.sql
@@ -61,10 +61,10 @@ joined as (
         end as model_type_prefix,
         case 
             when unioned_with_calc.resource_type in ('test', 'source', 'metric', 'exposure', 'seed') then null
-            when {{ dbt.position("concat('/',naming_convention_folders.folder_name_value,'/')",'unioned_with_calc.directory_path') }} = 0 then null
+            when {{ dbt.position(dbt.concat(["'" + get_directory_pattern() + "'",'naming_convention_folders.folder_name_value',"'" + get_directory_pattern() + "'"]),'unioned_with_calc.directory_path') }} = 0 then null
             else naming_convention_folders.model_type 
         end as model_type_folder,
-        {{ dbt.position("concat('/',naming_convention_folders.folder_name_value,'/')",'unioned_with_calc.directory_path') }} as position_folder,  
+        {{ dbt.position(dbt.concat(["'" + get_directory_pattern() + "'",'naming_convention_folders.folder_name_value',"'" + get_directory_pattern() + "'"]),'unioned_with_calc.directory_path') }} as position_folder,  
         nullif(unioned_with_calc.column_name, '') as column_name,
         {% for test in test_macro_list %}
         unioned_with_calc.macro_dependencies like '%macro.{{ test }}%' and unioned_with_calc.resource_type = 'test' as is_{{ test.split('.')[1] }},  

--- a/models/marts/core/int_all_graph_resources.sql
+++ b/models/marts/core/int_all_graph_resources.sql
@@ -61,10 +61,10 @@ joined as (
         end as model_type_prefix,
         case 
             when unioned_with_calc.resource_type in ('test', 'source', 'metric', 'exposure', 'seed') then null
-            when {{ dbt.position('naming_convention_folders.folder_name_value','unioned_with_calc.directory_path') }} = 0 then null
+            when {{ dbt.position("concat('/',naming_convention_folders.folder_name_value,'/')",'unioned_with_calc.directory_path') }} = 0 then null
             else naming_convention_folders.model_type 
         end as model_type_folder,
-        {{ dbt.position('naming_convention_folders.folder_name_value','unioned_with_calc.directory_path') }} as position_folder,  
+        {{ dbt.position("concat('/',naming_convention_folders.folder_name_value,'/')",'unioned_with_calc.directory_path') }} as position_folder,  
         nullif(unioned_with_calc.column_name, '') as column_name,
         {% for test in test_macro_list %}
         unioned_with_calc.macro_dependencies like '%macro.{{ test }}%' and unioned_with_calc.resource_type = 'test' as is_{{ test.split('.')[1] }},  


### PR DESCRIPTION
This is a:
- [x ] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
Closes #302 


## Description & motivation
Before the script was identifying a model's type by finding the latest position a model type's folder name appears in the model's directory path. Now the folder name has been concatenated with a '/' before meaning the search is for a key directory not the just the key word.

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)