### PR TITLE
add macro to restrict materializations for INSERT models

### DIFF
--- a/macros/check_model_is_table.sql
+++ b/macros/check_model_is_table.sql
@@ -1,0 +1,7 @@
+{%- macro check_model_is_table(model) -%}
+    {%- if model.config.materialized != 'table' -%}
+        {%- do exceptions.raise_compiler_error(
+            "Model must use the table materialization. Please check any model overrides."
+        ) -%}
+    {%- endif -%}
+{%- endmacro -%}

--- a/models/staging/graph/base/base_exposure_relationships.sql
+++ b/models/staging/graph/base/base_exposure_relationships.sql
@@ -5,6 +5,7 @@
     )
 }}
 
+{{ check_model_is_table(model) }}
 /* Bigquery won't let us `where` without `from` so we use this workaround */
 with dummy_cte as (
     select 1 as foo

--- a/models/staging/graph/base/base_metric_relationships.sql
+++ b/models/staging/graph/base/base_metric_relationships.sql
@@ -5,6 +5,7 @@
     )
 }}
 
+{{ check_model_is_table(model) }}
 /* Bigquery won't let us `where` without `from` so we use this workaround */
 with dummy_cte as (
     select 1 as foo

--- a/models/staging/graph/base/base_node_relationships.sql
+++ b/models/staging/graph/base/base_node_relationships.sql
@@ -5,6 +5,7 @@
     )
 }}
 
+{{ check_model_is_table(model) }}
 /* Bigquery won't let us `where` without `from` so we use this workaround */
 with dummy_cte as (
     select 1 as foo

--- a/models/staging/graph/stg_exposures.sql
+++ b/models/staging/graph/stg_exposures.sql
@@ -5,6 +5,7 @@
     )
 }}
 
+{{ check_model_is_table(model) }}
 /* Bigquery won't let us `where` without `from` so we use this workaround */
 with dummy_cte as (
     select 1 as foo

--- a/models/staging/graph/stg_metrics.sql
+++ b/models/staging/graph/stg_metrics.sql
@@ -5,6 +5,7 @@
     )
 }}
 
+{{ check_model_is_table(model) }}
 /* Bigquery won't let us `where` without `from` so we use this workaround */
 with dummy_cte as (
     select 1 as foo

--- a/models/staging/graph/stg_nodes.sql
+++ b/models/staging/graph/stg_nodes.sql
@@ -5,6 +5,7 @@
     )
 }}
 
+{{ check_model_is_table(model) }}
 /* Bigquery won't let us `where` without `from` so we use this workaround */
 with dummy_cte as (
     select 1 as foo

--- a/models/staging/graph/stg_sources.sql
+++ b/models/staging/graph/stg_sources.sql
@@ -5,7 +5,7 @@
     )
 }}
 
-
+{{ check_model_is_table(model) }}
 /* Bigquery won't let us `where` without `from` so we use this workaround */
 with dummy_cte as (
     select 1 as foo


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [x] new functionality

## Link to Issue 

#308 


## Description & motivation

Several users have stumbled on accidentally overriding the materializations for the base models in this project, which causes `INSERT`s to fail. 

This PR adds a macro to check that none of them have any materialization other than `table`. 

## Integration Test Screenshot

No changes to integration tests -- we don't have a "expected failure" mode in this testing suite like we might in pytest!

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)