### PR TITLE
Add `order_by` to `string_agg` for DuckDB

### DIFF
--- a/macros/cross_db_shim/duckdb_shims.sql
+++ b/macros/cross_db_shim/duckdb_shims.sql
@@ -14,14 +14,11 @@
     {% if limit_num -%}
         {%- do exceptions.raise_compiler_error("listagg on DuckDB doesn't support limit_num") -%}
     {%- endif %}
-    
-    {% if order_by_clause -%}
-        {%- do exceptions.warn("listagg on DuckDB doesn't support order_by_clause, you should order your data beforehand") -%}
-    {%- endif %}
 
     string_agg(
         {{ measure }}
         , {{ delimiter_text }}
+        {{ order_by_clause }}
         )
 
 {%- endmacro %}

--- a/models/marts/dag/fct_model_fanout.sql
+++ b/models/marts/dag/fct_model_fanout.sql
@@ -37,7 +37,7 @@ model_fanout_agg as (
         {{ dbt.listagg(
             measure = 'child', 
             delimiter_text = "', '", 
-            order_by_clause = 'order by child' if target.type in ['snowflake','redshift']) 
+            order_by_clause = 'order by child' if target.type in ['snowflake','redshift','duckdb']) 
         }} as leaf_children
     from model_fanout
     group by 1, 2

--- a/models/marts/dag/fct_multiple_sources_joined.sql
+++ b/models/marts/dag/fct_multiple_sources_joined.sql
@@ -16,7 +16,7 @@ multiple_sources_joined as (
         {{ dbt.listagg(
             measure='parent', 
             delimiter_text="', '", 
-            order_by_clause='order by parent' if target.type in ['snowflake','redshift']) 
+            order_by_clause='order by parent' if target.type in ['snowflake','redshift','duckdb']) 
         }} as source_parents
     from direct_source_relationships
     group by 1

--- a/models/marts/dag/fct_source_fanout.sql
+++ b/models/marts/dag/fct_source_fanout.sql
@@ -16,7 +16,7 @@ source_fanout as (
         {{ dbt.listagg(
             measure='child', 
             delimiter_text="', '", 
-            order_by_clause='order by child' if target.type in ['snowflake','redshift']) 
+            order_by_clause='order by child' if target.type in ['snowflake','redshift','duckdb']) 
         }} as model_children
     from direct_source_relationships
     group by 1

--- a/models/marts/structure/fct_model_naming_conventions.sql
+++ b/models/marts/structure/fct_model_naming_conventions.sql
@@ -17,7 +17,7 @@ appropriate_prefixes as (
         {{ dbt.listagg(
             measure='prefix_value', 
             delimiter_text="', '", 
-            order_by_clause='order by prefix_value' if target.type in ['snowflake','redshift']) 
+            order_by_clause='order by prefix_value' if target.type in ['snowflake','redshift','duckdb']) 
         }} as appropriate_prefixes
     from naming_convention_prefixes
     group by model_type


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->
Fixes #315 

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Add `order_by` support for `string_agg` as some integration tests were failing due to a different order of values in the column. 

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [x] DuckDB
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)