### PR TITLE
adjust root models to only filter excluded children nodes

### DIFF
--- a/models/marts/dag/fct_root_models.sql
+++ b/models/marts/dag/fct_root_models.sql
@@ -5,7 +5,8 @@ with model_relationships as (
         *
     from {{ ref('int_all_dag_relationships') }}
     where child_resource_type = 'model'
-    and not parent_is_excluded
+    -- only filter out excluded children nodes
+        -- filtering parents could result in incorrectly flagging nodes that depend on excluded nodes
     and not child_is_excluded
 ),
 


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->
Closes #344 

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

For `fct_root_models`, we should only filter out excluded children nodes (_not_ parents) - filtering parents could result in incorrectly flagging nodes that depend on excluded nodes.

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)