### PR TITLE
🐛 Fix exceptions, by reading `model.name`

### DIFF
--- a/macros/filter_exceptions.sql
+++ b/macros/filter_exceptions.sql
@@ -1,15 +1,15 @@
-{% macro filter_exceptions(model_ref) -%}
-    {{ return(adapter.dispatch('filter_exceptions', 'dbt_project_evaluator')(model_ref)) }}
+{% macro filter_exceptions(model_name) -%}
+    {{ return(adapter.dispatch('filter_exceptions', 'dbt_project_evaluator')(model_name)) }}
 {%- endmacro %}
 
-{% macro default__filter_exceptions(model_ref) %}
+{% macro default__filter_exceptions(model_name) %}
 
     {% set query_filters %}
     select
         column_name,
         id_to_exclude
     from {{ ref('dbt_project_evaluator_exceptions') }}
-    where fct_name = '{{ model_ref.name }}'
+    where fct_name = '{{ model_name }}'
     {% endset %}
 
     {% if execute %}

--- a/models/marts/dag/fct_direct_join_to_source.sql
+++ b/models/marts/dag/fct_direct_join_to_source.sql
@@ -35,4 +35,4 @@ final as (
 
 select * from final
 
-{{ filter_exceptions(this) }}
+{{ filter_exceptions(model.name) }}

--- a/models/marts/dag/fct_hard_coded_references.sql
+++ b/models/marts/dag/fct_hard_coded_references.sql
@@ -15,4 +15,4 @@ final as (
 
 select * from final
 
-{{ filter_exceptions(this) }}
+{{ filter_exceptions(model.name) }}

--- a/models/marts/dag/fct_marts_or_intermediate_dependent_on_source.sql
+++ b/models/marts/dag/fct_marts_or_intermediate_dependent_on_source.sql
@@ -17,4 +17,4 @@ final as (
 )
 select * from final
 
-{{ filter_exceptions(this) }}
+{{ filter_exceptions(model.name) }}

--- a/models/marts/dag/fct_model_fanout.sql
+++ b/models/marts/dag/fct_model_fanout.sql
@@ -46,4 +46,4 @@ model_fanout_agg as (
 
 select * from model_fanout_agg
 
-{{ filter_exceptions(this) }}
+{{ filter_exceptions(model.name) }}

--- a/models/marts/dag/fct_multiple_sources_joined.sql
+++ b/models/marts/dag/fct_multiple_sources_joined.sql
@@ -25,4 +25,4 @@ multiple_sources_joined as (
 
 select * from multiple_sources_joined
 
-{{ filter_exceptions(this) }}
+{{ filter_exceptions(model.name) }}

--- a/models/marts/dag/fct_rejoining_of_upstream_concepts.sql
+++ b/models/marts/dag/fct_rejoining_of_upstream_concepts.sql
@@ -64,4 +64,4 @@ final_filtered as (
 
 select * from final_filtered
 
-{{ filter_exceptions(this) }}
+{{ filter_exceptions(model.name) }}

--- a/models/marts/dag/fct_root_models.sql
+++ b/models/marts/dag/fct_root_models.sql
@@ -17,4 +17,4 @@ final as (
 
 select * from final
 
-{{ filter_exceptions(this) }}
+{{ filter_exceptions(model.name) }}

--- a/models/marts/dag/fct_source_fanout.sql
+++ b/models/marts/dag/fct_source_fanout.sql
@@ -25,4 +25,4 @@ source_fanout as (
 
 select * from source_fanout
 
-{{ filter_exceptions(this) }}
+{{ filter_exceptions(model.name) }}

--- a/models/marts/dag/fct_staging_dependent_on_marts_or_intermediate.sql
+++ b/models/marts/dag/fct_staging_dependent_on_marts_or_intermediate.sql
@@ -20,4 +20,4 @@ final as (
 )
 select * from final
 
-{{ filter_exceptions(this) }}
+{{ filter_exceptions(model.name) }}

--- a/models/marts/dag/fct_staging_dependent_on_staging.sql
+++ b/models/marts/dag/fct_staging_dependent_on_staging.sql
@@ -21,4 +21,4 @@ bending_connections as (
 
 select * from bending_connections
 
-{{ filter_exceptions(this) }}
+{{ filter_exceptions(model.name) }}

--- a/models/marts/dag/fct_unused_sources.sql
+++ b/models/marts/dag/fct_unused_sources.sql
@@ -17,4 +17,4 @@ final as (
 
 select * from final
 
-{{ filter_exceptions(this) }}
+{{ filter_exceptions(model.name) }}

--- a/models/marts/documentation/fct_undocumented_models.sql
+++ b/models/marts/documentation/fct_undocumented_models.sql
@@ -18,4 +18,4 @@ final as (
 
 select * from final
 
-{{ filter_exceptions(this) }}
+{{ filter_exceptions(model.name) }}

--- a/models/marts/performance/fct_chained_views_dependencies.sql
+++ b/models/marts/performance/fct_chained_views_dependencies.sql
@@ -18,6 +18,6 @@ final as (
 
 select * from final
 
-{{ filter_exceptions(this) }}
+{{ filter_exceptions(model.name) }}
 
 order by distance desc

--- a/models/marts/performance/fct_exposure_parents_materializations.sql
+++ b/models/marts/performance/fct_exposure_parents_materializations.sql
@@ -29,4 +29,4 @@ final as (
 
 select * from final
 
-{{ filter_exceptions(this) }}
+{{ filter_exceptions(model.name) }}

--- a/models/marts/structure/fct_model_directories.sql
+++ b/models/marts/structure/fct_model_directories.sql
@@ -65,6 +65,6 @@ unioned as (
 
 select * from unioned
 
-{{ filter_exceptions(this) }}
+{{ filter_exceptions(model.name) }}
  
 

--- a/models/marts/structure/fct_model_naming_conventions.sql
+++ b/models/marts/structure/fct_model_naming_conventions.sql
@@ -51,4 +51,4 @@ inappropriate_model_names as (
 
 select * from inappropriate_model_names
 
-{{ filter_exceptions(this) }}
+{{ filter_exceptions(model.name) }}

--- a/models/marts/structure/fct_source_directories.sql
+++ b/models/marts/structure/fct_source_directories.sql
@@ -22,4 +22,4 @@ inappropriate_subdirectories_sources as (
 
 select * from inappropriate_subdirectories_sources
 
-{{ filter_exceptions(this) }}
+{{ filter_exceptions(model.name) }}

--- a/models/marts/structure/fct_test_directories.sql
+++ b/models/marts/structure/fct_test_directories.sql
@@ -84,4 +84,4 @@ different_directories as (
 
 select * from different_directories
 
-{{ filter_exceptions(this) }}
+{{ filter_exceptions(model.name) }}

--- a/models/marts/tests/fct_missing_primary_key_tests.sql
+++ b/models/marts/tests/fct_missing_primary_key_tests.sql
@@ -1,3 +1,9 @@
+{{
+  config(
+    alias = 'my_alias',
+    )
+}}
+
 with 
 
 tests as (
@@ -15,4 +21,4 @@ final as (
 
 select * from final
 
-{{ filter_exceptions(this) }}
+{{ filter_exceptions(model.name) }}


### PR DESCRIPTION
`this.name` gives the table name and not the model name

This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->
Fixes #341

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

TIL that `this.name` returns the table/view name (a.k.a with `generate_alias_name()` applied), when `model.name` just returns the model name.

This is a breaking change (in case some people where using an updated `generate_alias_name()` and defining exceptions on those), but the updated behavior is the correct one.