### PR TITLE
Fix docs hyperlink path

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -12,7 +12,7 @@ hide:
 |Modeling                                      |[Rejoining of Upstream Concepts](../rules/modeling/#rejoining-of-upstream-concepts)                                    |`fct_rejoining_of_upstream_concepts`|
 |Modeling                                      |[Model Fanout](../rules/modeling/#model-fanout)                                                                        |`fct_model_fanout`|
 |Modeling                                      |[Downstream Models Dependent on Source](../rules/modeling/#downstream-models-dependent-on-source)                      |`fct_marts_or_intermediate_dependent_on_source`|
-|Modeling                                      |[Direct Join to Source](/..rules/modeling/#direct-join-to-source)                                                      |`fct_direct_join_to_source`|
+|Modeling                                      |[Direct Join to Source](../rules/modeling/#direct-join-to-source)                                                      |`fct_direct_join_to_source`|
 |Modeling                                      |[Duplicate Sources](../rules/modeling/#duplicate-sources)                                                              |`fct_duplicate_sources`|
 |Modeling                                      |[Hard Coded References](../rules/modeling/#hard-coded-references)                                                      |`fct_hard_coded_references`|
 |Modeling                                      |[Multiple Sources Joined](../rules/modeling/#multiple-sources-joined)                                                  |`fct_multiple_sources_joined`|


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->


## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
The `Direct Join to Source` hyperlink on [List of Rules page](https://dbt-labs.github.io/dbt-project-evaluator/0.6/rules/) is currently broken, linking to `https://dbt-labs.github.io/..rules/modeling/#direct-join-to-source` instead of `https://dbt-labs.github.io/dbt-project-evaluator/0.6/rules/modeling/#direct-join-to-source`
## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)