### PR TITLE
select only relevant columns in fct_direct_join_to_source

### DIFF
--- a/models/marts/dag/fct_direct_join_to_source.sql
+++ b/models/marts/dag/fct_direct_join_to_source.sql
@@ -27,7 +27,11 @@ model_and_source_joined as (
 
 final as (
     select 
-        direct_model_relationships.*
+        direct_model_relationships.parent,
+        direct_model_relationships.parent_resource_type,
+        direct_model_relationships.child,
+        direct_model_relationships.child_resource_type,
+        direct_model_relationships.distance
     from direct_model_relationships
     inner join model_and_source_joined
         on direct_model_relationships.child = model_and_source_joined.child


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->


## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

Previously, `fct_direct_join_to_source` was outputting a ton of unnecessary columns (all from `int_all_dag_relationships`) - this PR limits the outputted columns to only the relevant ones.

This could technically be a breaking change, if someone was filtering exceptions based on some of those columns

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)