### PR TITLE
only consider sql models in find_all_hard_coded_references

### DIFF
--- a/macros/find_all_hard_coded_references.sql
+++ b/macros/find_all_hard_coded_references.sql
@@ -6,7 +6,8 @@
 
     {%- set all_hard_coded_references_list = [] -%}
 
-    {% if node.resource_type == 'model' %}
+    {% if node.resource_type == 'model' and node.language == "sql" %}
+        {{ log(node.language, info=True) }}
 
         {% if execute %}
         {%- set model_raw_sql = node.raw_sql or node.raw_code -%}

--- a/macros/find_all_hard_coded_references.sql
+++ b/macros/find_all_hard_coded_references.sql
@@ -7,7 +7,6 @@
     {%- set all_hard_coded_references_list = [] -%}
 
     {% if node.resource_type == 'model' and node.language == "sql" %}
-        {{ log(node.language, info=True) }}
 
         {% if execute %}
         {%- set model_raw_sql = node.raw_sql or node.raw_code -%}


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
Closes #357


## Description & motivation

python models that use `from {{ package }} import {{ some stuff }}` syntax are getting flagged for using hard coded references! We should only run this check on sql models

The addition of a python model to the integration test suite is definitely possible, but would require having adapter specific settings to only run where python models exist, and a bunch of other edits to our seed files to keep it all in check. This feels low risk enough to me that I decided against all that, but can definitely reconsider if we decide this should be explicitly tested

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [x] DuckDB
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)