### PR TITLE
Add config for applying primary key test to other node types

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -57,6 +57,10 @@ vars:
 
   primary_key_test_macros: [["dbt.test_unique", "dbt.test_not_null"], ["dbt_utils.test_unique_combination_of_columns"]]
 
+  # -- Graph variables --
+  # node types to test for primary key coverage. acceptable node types: model, source, snapshot, seed
+  enforced_primary_key_node_types: ["model"]
+
   # -- DAG variables --
   models_fanout_threshold: 3
 

--- a/models/marts/tests/fct_missing_primary_key_tests.sql
+++ b/models/marts/tests/fct_missing_primary_key_tests.sql
@@ -1,9 +1,3 @@
-{{
-  config(
-    alias = 'my_alias',
-    )
-}}
-
 with 
 
 tests as (

--- a/models/marts/tests/fct_missing_primary_key_tests.sql
+++ b/models/marts/tests/fct_missing_primary_key_tests.sql
@@ -8,6 +8,10 @@ with
 
 tests as (
     select * from {{ ref('int_model_test_summary') }} 
+    where resource_type in
+    (
+        {% for resource_type in var('enforced_primary_key_node_types') %}'{{ resource_type }}'{% if not loop.last %},{% endif %}
+        {% endfor %}
 ),
 
 final as (

--- a/models/marts/tests/fct_missing_primary_key_tests.sql
+++ b/models/marts/tests/fct_missing_primary_key_tests.sql
@@ -12,6 +12,7 @@ tests as (
     (
         {% for resource_type in var('enforced_primary_key_node_types') %}'{{ resource_type }}'{% if not loop.last %},{% endif %}
         {% endfor %}
+    )
 ),
 
 final as (

--- a/models/marts/tests/fct_test_coverage.sql
+++ b/models/marts/tests/fct_test_coverage.sql
@@ -2,6 +2,7 @@ with
 
 test_counts as (
     select * from {{ ref('int_model_test_summary') }}
+    where resource_type = 'model'
 ),
 
 conversion as (

--- a/models/marts/tests/intermediate/int_model_test_summary.sql
+++ b/models/marts/tests/intermediate/int_model_test_summary.sql
@@ -62,7 +62,7 @@ final as (
     from all_graph_resources
     left join agg_test_relationships
         on all_graph_resources.resource_id = agg_test_relationships.direct_parent_id
-    where all_graph_resources.resource_type = 'model'
+    where all_graph_resources.resource_type in ('model', 'seed', 'source', 'snapshot')
 )
 
 select * from final

--- a/models/marts/tests/intermediate/int_model_test_summary.sql
+++ b/models/marts/tests/intermediate/int_model_test_summary.sql
@@ -56,13 +56,15 @@ agg_test_relationships as (
 final as (
     select 
         all_graph_resources.resource_name, 
+        all_graph_resources.resource_type,
         all_graph_resources.model_type,
         coalesce(agg_test_relationships.is_primary_key_tested, FALSE) as is_primary_key_tested,
         coalesce(agg_test_relationships.number_of_tests_on_model, 0) as number_of_tests_on_model
     from all_graph_resources
     left join agg_test_relationships
         on all_graph_resources.resource_id = agg_test_relationships.direct_parent_id
-    where all_graph_resources.resource_type in ('model', 'seed', 'source', 'snapshot')
+    where
+        all_graph_resources.resource_type in ('model', 'seed', 'source', 'snapshot')
 )
 
 select * from final


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes
- [X] new functionality

## Link to Issue 
Closes #358

## Description & motivation
This adds the ability to configure DBT project evaluator to add its primary key test enforcement to other node types, namely sources, snapshots, and seeds.

Snapshots certainly must have multi-field primary keys in order to function.

Sources and seeds always have inherent assumptions about their data structure when used. While users cannot always control the shape of input data, if a primary key is being assumed on these input data types, it is better to test on the source than downstream.

All of these configs are optional and set by the project variable `enforced_primary_key_node_types`.

This change could be breaking if users are building off of 

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [X] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)