### PR TITLE
Update broken links in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,11 +3,11 @@
 This package highlights areas of a dbt project that are misaligned with dbt Labs' best practices.
 Specifically, this package tests for:
 
-1. __[Modeling](./rules/modeling)__ - your dbt DAG for modeling best practices
-1. __[Testing](/rules/testing)__ - your models for testing best practices
-1. __[Documentation](/rules/documentation)__ - your models for documentation best practices
-1. __[Structure](/rules/structure)__ - your dbt project for file structure and naming best practices
-1. __[Performance](/rules/performance)__ - your model materializations for performance best practices
+1. __[Modeling](/main/rules/modeling)__ - your dbt DAG for modeling best practices
+1. __[Testing](/main/rules/testing)__ - your models for testing best practices
+1. __[Documentation](/main/rules/documentation)__ - your models for documentation best practices
+1. __[Structure](/main/rules/structure)__ - your dbt project for file structure and naming best practices
+1. __[Performance](/main/rules/performance)__ - your model materializations for performance best practices
 
 In addition to tests, this package creates the model `int_all_dag_relationships` which holds information about your DAG in a tabular format and can be queried using SQL in your Warehouse.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 This package highlights areas of a dbt project that are misaligned with dbt Labs' best practices.
 Specifically, this package tests for:
 
-1. __[Modeling](/rules/modeling)__ - your dbt DAG for modeling best practices
+1. __[Modeling](./rules/modeling)__ - your dbt DAG for modeling best practices
 1. __[Testing](/rules/testing)__ - your models for testing best practices
 1. __[Documentation](/rules/documentation)__ - your models for documentation best practices
 1. __[Structure](/rules/structure)__ - your dbt project for file structure and naming best practices


### PR DESCRIPTION
This is a:
- [X] bug fix PR with no breaking changes
- [ ] new functionality

## Description & motivation
These links are broken. For some reason, the relative paths do not work as I would anticipate. Navigating from `readme.md`, the link is `https://dbt-labs.github.io/dbt-project-evaluator/`, which forwards me to `https://dbt-labs.github.io/dbt-project-evaluator/0.6/`. Clicking on `modeling` sends me to `https://dbt-labs.github.io/rules/modeling` which does not exist. A valid page includes the version, such as `https://dbt-labs.github.io/main/rules/modeling`. I believe the attached changes should send users to an expected page. There may be a smarter way to manage these links to match the version of the home page you've landed on.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)