### PR TITLE
add excluded package

### DIFF
--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -59,7 +59,7 @@ seeds:
 
 vars:
   # ensure integration tests run successfully when there are 0 of a given model type (extra)
-  exclude_packages: []
+  exclude_packages: ['exclude_package']
   exclude_paths_from_project: ["/to_exclude/","source_3.table_6"]
   model_types: ['staging', 'intermediate', 'marts', 'other', 'extra', 'new_model_type']
   # dummy variable used for testing fct_hard_coded_references

--- a/integration_tests/exclude_package/dbt_project.yml
+++ b/integration_tests/exclude_package/dbt_project.yml
@@ -1,0 +1,30 @@
+
+# Name your project! Project names should contain only lowercase characters
+# and underscores. A good package name should reflect your organization's
+# name or the intended use of these models
+name: 'exclude_package'
+version: '1.0.0'
+config-version: 2
+
+# This setting configures which "profile" dbt uses for this project.
+profile: 'integration_tests'
+
+# These configurations specify where dbt should look for different types of files.
+# The `source-paths` config, for example, states that models in this project can be
+# found in the "models/" directory. You probably won't need to change these!
+model-paths: ["models"]
+analysis-paths: ["analysis"]
+test-paths: ["tests"]
+seed-paths: ["seeds"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+  - "target"
+  - "dbt_packages"
+
+models:
+  exclude_package:
+    # materialize as ephemeral to prevent the fake models from executing, but keep them enabled
+    +materialized: view

--- a/integration_tests/exclude_package/models/_models.yml
+++ b/integration_tests/exclude_package/models/_models.yml
@@ -1,0 +1,11 @@
+models:
+  - name: excluded_model
+    access: public
+    config: 
+      contract: 
+        enforced: true
+    columns: 
+      - name: id
+        data_type: integer
+      - name: data_quality
+        data_type: "{{ 'string' if target.type in ['bigquery', 'databricks'] else 'text' }}"

--- a/integration_tests/exclude_package/models/_models.yml
+++ b/integration_tests/exclude_package/models/_models.yml
@@ -7,5 +7,3 @@ models:
     columns: 
       - name: id
         data_type: integer
-      - name: data_quality
-        data_type: "{{ 'string' if target.type in ['bigquery', 'databricks'] else 'text' }}"

--- a/integration_tests/exclude_package/models/excluded_model.sql
+++ b/integration_tests/exclude_package/models/excluded_model.sql
@@ -1,0 +1,3 @@
+select 
+    1 as id,
+    'good' as data_quality

--- a/integration_tests/exclude_package/models/excluded_model.sql
+++ b/integration_tests/exclude_package/models/excluded_model.sql
@@ -1,3 +1,1 @@
-select 
-    1 as id,
-    'good' as data_quality
+select 1 as id

--- a/integration_tests/packages.yml
+++ b/integration_tests/packages.yml
@@ -1,2 +1,3 @@
 packages:
   - local: ../
+  - local: exclude_package/

--- a/models/marts/governance/fct_exposures_dependent_on_private_models.sql
+++ b/models/marts/governance/fct_exposures_dependent_on_private_models.sql
@@ -9,6 +9,7 @@ direct_exposure_relationships as (
                 parent_resource_type = 'model'
                 and parent_is_public
             )
+        and not parent_is_excluded
 ),
 
 final as (

--- a/models/marts/governance/fct_public_models_without_contract.sql
+++ b/models/marts/governance/fct_public_models_without_contract.sql
@@ -2,6 +2,7 @@ with
 
 all_resources as (
     select * from {{ ref('int_all_graph_resources') }}
+    where not is_excluded
 ),
 
 final as (

--- a/models/marts/governance/fct_undocumented_public_models.sql
+++ b/models/marts/governance/fct_undocumented_public_models.sql
@@ -2,6 +2,7 @@ with
 
 all_resources as (
     select * from {{ ref('int_all_graph_resources') }}
+    where not is_excluded
 ),
 
 final as (

--- a/models/marts/structure/fct_model_directories.sql
+++ b/models/marts/structure/fct_model_directories.sql
@@ -5,6 +5,7 @@
  
 with all_graph_resources as (
     select * from {{ ref('int_all_graph_resources') }}
+    where not is_excluded
 ),
 
 folders as (


### PR DESCRIPTION
This is a:
- [ =x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 

Closes #370 


## Description & motivation

When we rolled out the new logic to add `is_excluded`, we missed adding the filter for excluded items in `fct_model_directories`!

I went back and double checked, and I had also missed this on the new governance features that were written before that refactoring work. 

This PR adds those filters, as well as a new package that integration tests depends on but ignores!


## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [x] Databricks
    - [x] DuckDB
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)