### PR TITLE
Support uniqness test defined several times

### DIFF
--- a/models/marts/tests/intermediate/int_model_test_summary.sql
+++ b/models/marts/tests/intermediate/int_model_test_summary.sql
@@ -40,7 +40,7 @@ agg_test_relationships as (
                 when (
                     {%- for test_set in var('primary_key_test_macros') %}
                         {%- set compare_value = test_set | length %}
-                    primary_key_method_{{ loop.index }}_count = {{ compare_value}}
+                    primary_key_method_{{ loop.index }}_count >= {{ compare_value}}
                         {%- if not loop.last %} or {% endif %}
                     {%- endfor %} 
                 ) then 1 


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
No reported issue


## Description & motivation
Our team has 2 `dbt_utils.unique_combination_of_columns` tests defined for the same model. Column set is different.
Latest release reports this case as a failure:

```markdown
-- is_empty_fct_missing_primary_key_tests_ --
| RESOURCE_NAME             | RESOURCE_TYPE | MODEL_TYPE | IS_PRIMARY_KEY_TESTED | NUMBER_OF_TESTS_ON_MODEL |
| ------------------------- | ------------- | ---------- | --------------------- | ------------------------ |
| stg_xxx_yy__model_name_xx | model         | staging    |                 False |                        2 |
```

## Integration Test Screenshot
TO BE DONE

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
    - [ ] Trino/Starburst
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)