### PR TITLE
add base models to accepted model types. 

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -67,12 +67,14 @@ vars:
   # -- Naming conventions variables --
   # to add a new "model type", update the variable model_types 
   # and create new variables with the names <model_type>_folder_name and/or <model_type>_prefixes 
-  model_types: ['staging', 'intermediate', 'marts', 'other']
+  model_types: ['base', 'staging', 'intermediate', 'marts', 'other']
 
+  base_folder_name: 'base'
   staging_folder_name: 'staging'
   intermediate_folder_name: 'intermediate'
   marts_folder_name: 'marts'
   
+  base_prefixes: ['base_']
   staging_prefixes: ['stg_']
   intermediate_prefixes: ['int_']
   marts_prefixes: ['fct_', 'dim_']

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -61,7 +61,7 @@ vars:
   # ensure integration tests run successfully when there are 0 of a given model type (extra)
   exclude_packages: ['exclude_package']
   exclude_paths_from_project: ["/to_exclude/","source_3.table_6"]
-  model_types: ['staging', 'intermediate', 'marts', 'other', 'extra', 'new_model_type']
+  model_types: ['base','staging', 'intermediate', 'marts', 'other', 'extra', 'new_model_type']
   # dummy variable used for testing fct_hard_coded_references
   my_table_reference: 'grace_table'
   new_model_type_folder_name: 'my_new_models'

--- a/integration_tests/models/dbt_project_evaluator_schema_tests/core.yml
+++ b/integration_tests/models/dbt_project_evaluator_schema_tests/core.yml
@@ -23,8 +23,10 @@ models:
           - is_not_empty_string
       - name: model_type
         tests: 
-          - accepted_values:
-              values: "{{ var('model_types') }}"
+          - dbt_utils.expression_is_true:
+              expression: "= 'base'"
+              config:
+                where: "resource_name = 'base_model_10'"
 
   - name: int_direct_relationships
     description: "This table shows one record for each direct parent/child pair in the graph."

--- a/integration_tests/models/dbt_project_evaluator_schema_tests/core.yml
+++ b/integration_tests/models/dbt_project_evaluator_schema_tests/core.yml
@@ -21,6 +21,10 @@ models:
         description: this contains the on_schema_change setting for incremental models. This column was sometimes an empty string, so should be tested to detect regressions
         tests:
           - is_not_empty_string
+      - name: model_type
+        tests: 
+          - accepted_values:
+              values: "{{ var('model_types') }}"
 
   - name: int_direct_relationships
     description: "This table shows one record for each direct parent/child pair in the graph."

--- a/integration_tests/models/staging/staging.yml
+++ b/integration_tests/models/staging/staging.yml
@@ -2,7 +2,6 @@ version: 2
 
 models:
   - name: stg_model_4
-    description: " "
     columns:
       - name: id
         tests:

--- a/integration_tests/models/staging/staging.yml
+++ b/integration_tests/models/staging/staging.yml
@@ -2,6 +2,7 @@ version: 2
 
 models:
   - name: stg_model_4
+    description: " "
     columns:
       - name: id
         tests:

--- a/integration_tests/models/staging/to_exclude/base/base_model_10.sql
+++ b/integration_tests/models/staging/to_exclude/base/base_model_10.sql
@@ -1,0 +1,3 @@
+
+
+select true


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
Closes #387 


## Description & motivation

Adds base models as an acceptable model type. 

Chose to exclude the new model i added to the integration tests so as not to have to edit all the test and documentation related seeds, but validated the output in `int_all_graph_resources`:

<img width="1118" alt="image" src="https://github.com/dbt-labs/dbt-project-evaluator/assets/73915542/bbdd2d2f-9c1e-4a62-8fad-77a992bf9acd">


I also added an accepted values test to make sure the types match the variable -- not a perfect test, but at least protects against nulls and/or some faulty logic


## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
    - [ ] Trino/Starburst
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)