### PR TITLE
fix governance exclusion macro

### DIFF
--- a/models/marts/governance/fct_exposures_dependent_on_private_models.sql
+++ b/models/marts/governance/fct_exposures_dependent_on_private_models.sql
@@ -26,4 +26,4 @@ final as (
 
 select * from final
 
-{{ filter_exceptions(this) }}
+{{ filter_exceptions(model.name) }}

--- a/models/marts/governance/fct_public_models_without_contract.sql
+++ b/models/marts/governance/fct_public_models_without_contract.sql
@@ -20,4 +20,4 @@ final as (
 
 select * from final
 
-{{ filter_exceptions(this) }}
+{{ filter_exceptions(model.name) }}

--- a/models/marts/governance/fct_undocumented_public_models.sql
+++ b/models/marts/governance/fct_undocumented_public_models.sql
@@ -28,4 +28,4 @@ final as (
 
 select * from final
 
-{{ filter_exceptions(this) }}
+{{ filter_exceptions(model.name) }}


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
Closes #396 


## Description & motivation

Governance models were made without the correct macro call to exclude models -- this should fix it!

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [x] DuckDB
    - [ ] Trino/Starburst
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)