### PR TITLE
Handle single quote in owner name and update test

### DIFF
--- a/integration_tests/models/marts/exposures.yml
+++ b/integration_tests/models/marts/exposures.yml
@@ -2,13 +2,13 @@ version: 2
 
 exposures:
   - name: exposure_1
-    description: real_dashboard
+    description: real_dashboard with fun chars '\!@#
     type: dashboard
     url: dave.com/metrics
     maturity: low
     tags: ['proserv']
     owner:
-      name: proserv
+      name: dave's davey
       email: proserv@dbt.com
     
     depends_on:

--- a/macros/unpack/get_exposure_values.sql
+++ b/macros/unpack/get_exposure_values.sql
@@ -23,7 +23,7 @@
               wrap_string_with_quotes(node.package_name),
               wrap_string_with_quotes(node.url),
               wrap_string_with_quotes(dbt.escape_single_quotes(node.owner.name)),
-              wrap_string_with_quotes(node.owner.email),
+              wrap_string_with_quotes(dbt.escape_single_quotes(node.owner.email)),
               wrap_string_with_quotes(node.meta | tojson)
             ]
           %}

--- a/macros/unpack/get_exposure_values.sql
+++ b/macros/unpack/get_exposure_values.sql
@@ -22,7 +22,7 @@
               wrap_string_with_quotes(node.maturity),
               wrap_string_with_quotes(node.package_name),
               wrap_string_with_quotes(node.url),
-              wrap_string_with_quotes(node.owner.name),
+              wrap_string_with_quotes(dbt.escape_single_quotes(node.owner.name)),
               wrap_string_with_quotes(node.owner.email),
               wrap_string_with_quotes(node.meta | tojson)
             ]


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->
Related to #405


## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
There is currently a bug if the owner name contains a single quote. I have updated the integration tests to fail without the fix and pass with it.

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
    - [ ] Trino/Starburst
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)