### PR TITLE
feat: Log own custom rules

### DIFF
--- a/docs/customization/issues-in-log.md
+++ b/docs/customization/issues-in-log.md
@@ -73,5 +73,5 @@ By setting `dbt_project_evaluator.is_empty`, you can see the result like:
 | fct_my_public_model                |      True |                False |
 ```
 
-As you can see, custom rules and official rules can be identified by the prefix of test_name (`my_dbt_package.` and
+Custom rules and official rules can be identified by the prefix of test_name (`my_dbt_package.` and
 `dbt_project_evaluator.`).

--- a/docs/customization/issues-in-log.md
+++ b/docs/customization/issues-in-log.md
@@ -73,5 +73,5 @@ By setting `dbt_project_evaluator.is_empty`, you can see the result like:
 | fct_my_public_model                |      True |                False |
 ```
 
-Custom rules and official rules can be identified by the prefix of test_name (`my_dbt_package.` and
+Custom rules and official rules can be identified by the test name prefix (`my_dbt_package.` and
 `dbt_project_evaluator.`).

--- a/docs/customization/issues-in-log.md
+++ b/docs/customization/issues-in-log.md
@@ -18,60 +18,10 @@ The macro accepts two parameters:
 You can also log the results of your custom rules by applying `dbt_project_evaluator.is_empty` to
 the custom models.
 
-Here is the example code:
-
 ```yaml
-# {{ your dbt project dir }}/models/dbt_project_evaluator/fct_public_models_without_exposures.sql
-
-with
-    public_models as (
-        select *
-        from {{ ref("dbt_project_evaluator", "int_all_graph_resources") }}
-        where resource_type = 'model' and is_public and not is_excluded
-    ),
-    models_with_exposure as (
-        select direct_parent_id as resource_id
-        from {{ ref("dbt_project_evaluator", "base_exposure_relationships") }}
-    ),
-    final as (
-        select resource_name as model_name, is_public, false as has_exposure
-        from public_models m
-        where
-            not exists (
-                select 1 from models_with_exposure e where m.resource_id = e.resource_id
-            )
-    )
-
-select *
-from final {{ dbt_project_evaluator.filter_exceptions(model.name) }} -- to enable exceptions
-```
-
-```yaml
-# {{ dbt project dir }}/models/dbt_project_evaluator/governance.yml
-
 models:
-  - name: fct_public_models_without_exposures
-    description: This table shows each public model that does not have an exposure
+  - name: my_custom_rule_model
+    description: This is my custom project evaluator check 
     tests:
       - dbt_project_evaluator.is_empty
 ```
-
-By setting `dbt_project_evaluator.is_empty`, you can see the result like:
-
-```
-### List of issues raised by dbt_project_evaluator ###
-
--- my_dbt_package.dbt_project_evaluator.dbt_project_evaluator_is_empty_fct_public_models_without_exposures_ --
-| MODEL_NAME                         | IS_PUBLIC | HAS_EXPOSURE |
-| ---------------------------------- | --------- | ------------ |
-| fct_my_public_model                |      True |        False |
-
-
--- dbt_project_evaluator.marts.governance.is_empty_fct_public_models_without_contract_ --
-| RESOURCE_NAME                      | IS_PUBLIC | IS_CONTRACT_ENFORCED |
-| ---------------------------------- | --------- | -------------------- |
-| fct_my_public_model                |      True |                False |
-```
-
-Custom rules and official rules can be identified by the test name prefix (`my_dbt_package.` and
-`dbt_project_evaluator.`).

--- a/docs/customization/issues-in-log.md
+++ b/docs/customization/issues-in-log.md
@@ -12,3 +12,66 @@ The macro accepts two parameters:
 
 - to pick between 2 types of formatting, set `format='table'` (default) or `format='csv'`
 - to add quotes to the database and schema (default = no quote), set ``quote='`'`` or `quote='"'`
+
+## Logging your custom rules
+
+You can also log the results of your custom rules by applying `dbt_project_evaluator.is_empty` to
+the custom models.
+
+Here is the example code:
+
+```yaml
+# {{ your dbt project dir }}/models/dbt_project_evaluator/fct_public_models_without_exposures.sql
+
+with
+    public_models as (
+        select *
+        from {{ ref("dbt_project_evaluator", "int_all_graph_resources") }}
+        where resource_type = 'model' and is_public and not is_excluded
+    ),
+    models_with_exposure as (
+        select direct_parent_id as resource_id
+        from {{ ref("dbt_project_evaluator", "base_exposure_relationships") }}
+    ),
+    final as (
+        select resource_name as model_name, is_public, false as has_exposure
+        from public_models m
+        where
+            not exists (
+                select 1 from models_with_exposure e where m.resource_id = e.resource_id
+            )
+    )
+
+select *
+from final {{ dbt_project_evaluator.filter_exceptions(model.name) }} -- to enable exceptions
+```
+
+```yaml
+# {{ dbt project dir }}/models/dbt_project_evaluator/governance.yml
+
+models:
+  - name: fct_public_models_without_exposures
+    description: This table shows each public model that does not have an exposure
+    tests:
+      - dbt_project_evaluator.is_empty
+```
+
+By setting `dbt_project_evaluator.is_empty`, you can see the result like:
+
+```
+### List of issues raised by dbt_project_evaluator ###
+
+-- my_dbt_package.dbt_project_evaluator.dbt_project_evaluator_is_empty_fct_public_models_without_exposures_ --
+| MODEL_NAME                         | IS_PUBLIC | HAS_EXPOSURE |
+| ---------------------------------- | --------- | ------------ |
+| fct_my_public_model                |      True |        False |
+
+
+-- dbt_project_evaluator.marts.governance.is_empty_fct_public_models_without_contract_ --
+| RESOURCE_NAME                      | IS_PUBLIC | IS_CONTRACT_ENFORCED |
+| ---------------------------------- | --------- | -------------------- |
+| fct_my_public_model                |      True |                False |
+```
+
+As you can see, custom rules and official rules can be identified by the prefix of test_name (`my_dbt_package.` and
+`dbt_project_evaluator.`).

--- a/macros/on-run-end/print_dbt_project_evaluator_issues.sql
+++ b/macros/on-run-end/print_dbt_project_evaluator_issues.sql
@@ -22,7 +22,7 @@
         or resource_name.startswith(test_name_prefix_of_custom_rules)
       ) %}
         
-        {{ print("\n-- " ~ result.node.alias ~ " --") }}
+        {{ print("\n-- " ~ result.node.fqn | join(".") ~ " --") }}
 
         {% set unique_id_model_checked = result.node.depends_on.nodes[0] %}
 

--- a/macros/on-run-end/print_dbt_project_evaluator_issues.sql
+++ b/macros/on-run-end/print_dbt_project_evaluator_issues.sql
@@ -3,9 +3,24 @@
   {%- if flags.WHICH in ["build","test"] -%}
     {{ print("\n### List of issues raised by dbt_project_evaluator ###") }}
 
+    {#-
+      if you create custom dbt_project_evaluator rules on your package using the test `dbt_project_evaluator.is_empty`,
+      the test name should start with the same name as the default.
+    -#}
+    {% set test_name_prefix_of_custom_rules = var(
+      "test_name_prefix_of_custom_rules",
+      default="dbt_project_evaluator_is_empty_",
+    ) %}
+
     {% for result in results | selectattr('failures') | selectattr('failures', '>', 0) %}
       
-      {% if result.node.fqn[0] == "dbt_project_evaluator" %}
+      {% set is_test = result.node.config.materialized == "test" %}
+      {% set package_name = result.node.package_name %}
+      {% set resource_name = result.node.name %}
+      {% if is_test and (
+        package_name == "dbt_project_evaluator"
+        or resource_name.startswith(test_name_prefix_of_custom_rules)
+      ) %}
         
         {{ print("\n-- " ~ result.node.alias ~ " --") }}
 


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes
- [x] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->

https://github.com/dbt-labs/dbt-project-evaluator/issues/407

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

Enable also to log error of our own rules by `print_dbt_project_evaluator_issues`

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

./run_test.sh snowflake

<img width="924" alt="スクリーンショット 2023-12-21 10 45 47" src="https://github.com/dbt-labs/dbt-project-evaluator/assets/28292300/1c69f3ac-ca49-43a7-ad8a-8109b1b200d4">


## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
    - [ ] Trino/Starburst
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)


## Usecase 

My custom rules is like that.

`{{ dbt project dir }}/models/dbt_project_evaluator/fct_public_models_without_exposures.sql`
```sql
with
    public_models as (
        select *
        from {{ ref("dbt_project_evaluator", "int_all_graph_resources") }}
        where resource_type = 'model' and is_public and not is_excluded
    ),
    models_with_exposure as (
        select direct_parent_id as resource_id
        from {{ ref("dbt_project_evaluator", "base_exposure_relationships") }}
    ),
    final as (
        select resource_name as model_name, is_public, false as has_exposure
        from public_models m
        where
            not exists (
                select 1 from models_with_exposure e where m.resource_id = e.resource_id
            )
    )

select *
from final {{ dbt_project_evaluator.filter_exceptions(model.name) }}
```

`{{ dbt project dir }}/models/dbt_project_evaluator/governance.yml`
```yaml
models:
  - name: fct_public_models_without_exposures
    description: This table shows each public model that does not have an exposure
    tests:
      - dbt_project_evaluator.is_empty:
          config:
            severity: "{{ env_var('DBT_PROJECT_EVALUATOR_SEVERITY', 'error') }}"
            store_failures_as: ephemeral
```

### Log example

logged like that (using fqn because package my test alias show random_strings like `dbt_project_evaluator_is_empty_{{ random_strings }}`)

```
### List of issues raised by dbt_project_evaluator ###

-- my_dbt_package.dbt_project_evaluator.dbt_project_evaluator_is_empty_fct_public_models_without_exposures_ --
| MODEL_NAME                         | IS_PUBLIC | HAS_EXPOSURE |
| ---------------------------------- | --------- | ------------ |
| workspace_sandbox_dbt_sample_model |      True |        False |


-- dbt_project_evaluator.marts.governance.is_empty_fct_public_models_without_contract_ --
| RESOURCE_NAME                      | IS_PUBLIC | IS_CONTRACT_ENFORCED |
| ---------------------------------- | --------- | -------------------- |
| workspace_sandbox_dbt_sample_model |      True |                False |


-- dbt_project_evaluator.marts.governance.is_empty_fct_undocumented_public_models_ --
| RESOURCE_NAME                      | ACCESS | IS_DESCRIBED | TOTAL_DEFINED_COLUMNS | TOTAL_DESCRIBED_COLUMNS |
| ---------------------------------- | ------ | ------------ | --------------------- | ----------------------- |
| workspace_sandbox_dbt_sample_model | public |         True |                     1 |                       0 |
```
