### PR TITLE
Exclude "distinct from" from hard coded references flag

### DIFF
--- a/integration_tests/models/marts/int_model_5.sql
+++ b/integration_tests/models/marts/int_model_5.sql
@@ -1,3 +1,5 @@
--- {{ ref('int_model_4') }}
--- {{ ref('stg_model_1') }}
 select 1 as id
+-- from {{ ref('int_model_4') }}
+-- inner join {{ ref('stg_model_1') }}
+-- on int_model_4.join_field = stg_model_1.join_field
+-- where int_model_4.id is distinct from stg_model_1.id

--- a/integration_tests/models/staging/stg_model_5.sql
+++ b/integration_tests/models/staging/stg_model_5.sql
@@ -1,6 +1,3 @@
 select 
     * 
 from {{ ref('fct_model_9') }}
--- inner join {{ ref('fct_model_6') }}
--- on fct_model_9.join_field = fct_model_6.join_field
--- where fct_model_9.id is distinct from fct_model_6.id

--- a/integration_tests/models/staging/stg_model_5.sql
+++ b/integration_tests/models/staging/stg_model_5.sql
@@ -1,1 +1,6 @@
-{{ ref('fct_model_9') }}
+select 
+    * 
+from {{ ref('fct_model_9') }}
+-- inner join {{ ref('fct_model_6') }}
+-- on fct_model_9.join_field = fct_model_6.join_field
+-- where fct_model_9.id is distinct from fct_model_6.id

--- a/macros/find_all_hard_coded_references.sql
+++ b/macros/find_all_hard_coded_references.sql
@@ -35,6 +35,9 @@
             - matches (from or join) followed by some spaces and then <something>
               where <something> is enclosed by (` or [ or " or ')
 
+            # notes
+            - all regex matches exclude text that immediately follows "distinct "
+
         -#}
 
         {%- set re = modules.re -%}
@@ -42,6 +45,9 @@
         {%- set from_hard_coded_references = {
             'from_var_1':
                 '(?ix)
+
+                # NOT following "distinct "
+                (?<!distinct\s)
 
                 # first matching group
                 # from or join followed by at least 1 whitespace character
@@ -66,6 +72,9 @@
                 ',
             'from_var_2':
                 '(?ix)
+
+                # NOT following "distinct "
+                (?<!distinct\s)
 
                 # first matching group
                 # from or join followed by at least 1 whitespace character
@@ -107,6 +116,9 @@
             'from_table_1':
                 '(?ix)
 
+                # NOT following "distinct "
+                (?<!distinct\s)
+
                 # first matching group
                 # from or join followed by at least 1 whitespace character            
                 (from|join)\s+
@@ -143,6 +155,9 @@
             'from_table_2':
                 '(?ix)
 
+                # NOT following "distinct "
+                (?<!distinct\s)
+
                 # first matching group
                 # from or join followed by at least 1 whitespace character 
                 (from|join)\s+
@@ -154,6 +169,7 @@
                 # third matching group
                 # at least 1 word character
                 (\w+)
+
                 # fouth matching group
                 # 1 or 0 of (closing bracket, backtick, or quotation mark)            
                 ([\]`\"\']?)
@@ -187,12 +203,15 @@
                 (\w+)
 
                 # twelfth matching group
-                # 1 or 0 of (closing bracket, backtick, or quotation mark) folowed by a whitespace character or end of string
+                # 1 or 0 of (closing bracket, backtick, or quotation mark) followed by a whitespace character or end of string
                 ([\]`\"\']?)(?=\s|$)
 
                 ',
             'from_table_3':
                 '(?ix)
+
+                # NOT following "distinct "
+                (?<!distinct\s)
 
                 # first matching group
                 # from or join followed by at least 1 whitespace character             
@@ -203,8 +222,8 @@
                 ([\[`\"\'])
 
                 # third matching group
-                # at least 1 word character or space 
-                ([\w ]+)
+                # at least 1 word character
+                (\w+)
                 
                 # fourth matching group
                 # 1 of (closing bracket, backtick, or quotation mark) folowed by a whitespace character or end of string


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
Closes https://github.com/dbt-labs/dbt-project-evaluator/issues/338

## Description & motivation
SQL that uses `is distinct from` or `is not distinct from` is being incorrectly flagged as a hard coded reference. 

Example:
```
    select
        old.* exclude (fact_effective_thru, fact_history_is_current) 
        ,current_timestamp() as fact_effective_thru
        ,false as fact_history_is_current
    from
        {{ref(old_state)}} as old
    inner join {{ref(new_state)}} as new
        using(fact_durable_key)
    where
        old.ALL_SOURCE_ATTRIBUTES is distinct from new.ALL_SOURCE_ATTRIBUTES
```
`new.ALL_SOURCE_ATTRIBUTES` is being flagged.

I added a negative lookback for `distinct ` to all regex checks.

## Integration Test Screenshot
![Screenshot 2024-01-04 at 3 55 43 PM](https://github.com/dbt-labs/dbt-project-evaluator/assets/53586774/90e998d5-b1e4-4e33-85b2-faab590b0d48)

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
    - [ ] Trino/Starburst
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)