### PR TITLE
Remove arg from `filter_exceptions`

### DIFF
--- a/macros/filter_exceptions.sql
+++ b/macros/filter_exceptions.sql
@@ -1,15 +1,15 @@
-{% macro filter_exceptions(model_name) -%}
-    {{ return(adapter.dispatch('filter_exceptions', 'dbt_project_evaluator')(model_name)) }}
+{% macro filter_exceptions() -%}
+    {{ return(adapter.dispatch('filter_exceptions', 'dbt_project_evaluator')()) }}
 {%- endmacro %}
 
-{% macro default__filter_exceptions(model_name) %}
+{% macro default__filter_exceptions() %}
 
     {% set query_filters %}
     select
         column_name,
         id_to_exclude
     from {{ ref('dbt_project_evaluator_exceptions') }}
-    where fct_name = '{{ model_name }}'
+    where fct_name = '{{ model.name }}'
     {% endset %}
 
     {% if execute %}

--- a/models/marts/dag/fct_direct_join_to_source.sql
+++ b/models/marts/dag/fct_direct_join_to_source.sql
@@ -41,4 +41,4 @@ final as (
 
 select * from final
 
-{{ filter_exceptions(model.name) }}
+{{ filter_exceptions() }}

--- a/models/marts/dag/fct_hard_coded_references.sql
+++ b/models/marts/dag/fct_hard_coded_references.sql
@@ -16,4 +16,4 @@ final as (
 
 select * from final
 
-{{ filter_exceptions(model.name) }}
+{{ filter_exceptions() }}

--- a/models/marts/dag/fct_marts_or_intermediate_dependent_on_source.sql
+++ b/models/marts/dag/fct_marts_or_intermediate_dependent_on_source.sql
@@ -19,4 +19,4 @@ final as (
 )
 select * from final
 
-{{ filter_exceptions(model.name) }}
+{{ filter_exceptions() }}

--- a/models/marts/dag/fct_model_fanout.sql
+++ b/models/marts/dag/fct_model_fanout.sql
@@ -48,4 +48,4 @@ model_fanout_agg as (
 
 select * from model_fanout_agg
 
-{{ filter_exceptions(model.name) }}
+{{ filter_exceptions() }}

--- a/models/marts/dag/fct_multiple_sources_joined.sql
+++ b/models/marts/dag/fct_multiple_sources_joined.sql
@@ -27,4 +27,4 @@ multiple_sources_joined as (
 
 select * from multiple_sources_joined
 
-{{ filter_exceptions(model.name) }}
+{{ filter_exceptions() }}

--- a/models/marts/dag/fct_rejoining_of_upstream_concepts.sql
+++ b/models/marts/dag/fct_rejoining_of_upstream_concepts.sql
@@ -66,4 +66,4 @@ final_filtered as (
 
 select * from final_filtered
 
-{{ filter_exceptions(model.name) }}
+{{ filter_exceptions() }}

--- a/models/marts/dag/fct_root_models.sql
+++ b/models/marts/dag/fct_root_models.sql
@@ -22,4 +22,4 @@ final as (
 
 select * from final
 
-{{ filter_exceptions(model.name) }}
+{{ filter_exceptions() }}

--- a/models/marts/dag/fct_source_fanout.sql
+++ b/models/marts/dag/fct_source_fanout.sql
@@ -27,4 +27,4 @@ source_fanout as (
 
 select * from source_fanout
 
-{{ filter_exceptions(model.name) }}
+{{ filter_exceptions() }}

--- a/models/marts/dag/fct_staging_dependent_on_marts_or_intermediate.sql
+++ b/models/marts/dag/fct_staging_dependent_on_marts_or_intermediate.sql
@@ -22,4 +22,4 @@ final as (
 )
 select * from final
 
-{{ filter_exceptions(model.name) }}
+{{ filter_exceptions() }}

--- a/models/marts/dag/fct_staging_dependent_on_staging.sql
+++ b/models/marts/dag/fct_staging_dependent_on_staging.sql
@@ -23,4 +23,4 @@ bending_connections as (
 
 select * from bending_connections
 
-{{ filter_exceptions(model.name) }}
+{{ filter_exceptions() }}

--- a/models/marts/dag/fct_unused_sources.sql
+++ b/models/marts/dag/fct_unused_sources.sql
@@ -19,4 +19,4 @@ final as (
 
 select * from final
 
-{{ filter_exceptions(model.name) }}
+{{ filter_exceptions() }}

--- a/models/marts/documentation/fct_undocumented_models.sql
+++ b/models/marts/documentation/fct_undocumented_models.sql
@@ -19,4 +19,4 @@ final as (
 
 select * from final
 
-{{ filter_exceptions(model.name) }}
+{{ filter_exceptions() }}

--- a/models/marts/documentation/fct_undocumented_source_tables.sql
+++ b/models/marts/documentation/fct_undocumented_source_tables.sql
@@ -18,4 +18,4 @@ final as (
 
 select * from final
 
-{{ filter_exceptions(model.name) }}
+{{ filter_exceptions() }}

--- a/models/marts/documentation/fct_undocumented_sources.sql
+++ b/models/marts/documentation/fct_undocumented_sources.sql
@@ -18,4 +18,4 @@ final as (
 
 select * from final
 
-{{ filter_exceptions(model.name) }}
+{{ filter_exceptions() }}

--- a/models/marts/governance/fct_exposures_dependent_on_private_models.sql
+++ b/models/marts/governance/fct_exposures_dependent_on_private_models.sql
@@ -26,4 +26,4 @@ final as (
 
 select * from final
 
-{{ filter_exceptions(model.name) }}
+{{ filter_exceptions() }}

--- a/models/marts/governance/fct_public_models_without_contract.sql
+++ b/models/marts/governance/fct_public_models_without_contract.sql
@@ -20,4 +20,4 @@ final as (
 
 select * from final
 
-{{ filter_exceptions(model.name) }}
+{{ filter_exceptions() }}

--- a/models/marts/governance/fct_undocumented_public_models.sql
+++ b/models/marts/governance/fct_undocumented_public_models.sql
@@ -28,4 +28,4 @@ final as (
 
 select * from final
 
-{{ filter_exceptions(model.name) }}
+{{ filter_exceptions() }}

--- a/models/marts/performance/fct_chained_views_dependencies.sql
+++ b/models/marts/performance/fct_chained_views_dependencies.sql
@@ -20,6 +20,6 @@ final as (
 
 select * from final
 
-{{ filter_exceptions(model.name) }}
+{{ filter_exceptions() }}
 
 order by distance desc

--- a/models/marts/performance/fct_exposure_parents_materializations.sql
+++ b/models/marts/performance/fct_exposure_parents_materializations.sql
@@ -31,4 +31,4 @@ final as (
 
 select * from final
 
-{{ filter_exceptions(model.name) }}
+{{ filter_exceptions() }}

--- a/models/marts/structure/fct_model_directories.sql
+++ b/models/marts/structure/fct_model_directories.sql
@@ -67,6 +67,6 @@ unioned as (
 
 select * from unioned
 
-{{ filter_exceptions(model.name) }}
+{{ filter_exceptions() }}
  
 

--- a/models/marts/structure/fct_model_naming_conventions.sql
+++ b/models/marts/structure/fct_model_naming_conventions.sql
@@ -54,4 +54,4 @@ inappropriate_model_names as (
 
 select * from inappropriate_model_names
 
-{{ filter_exceptions(model.name) }}
+{{ filter_exceptions() }}

--- a/models/marts/structure/fct_source_directories.sql
+++ b/models/marts/structure/fct_source_directories.sql
@@ -23,4 +23,4 @@ inappropriate_subdirectories_sources as (
 
 select * from inappropriate_subdirectories_sources
 
-{{ filter_exceptions(model.name) }}
+{{ filter_exceptions() }}

--- a/models/marts/structure/fct_test_directories.sql
+++ b/models/marts/structure/fct_test_directories.sql
@@ -85,4 +85,4 @@ different_directories as (
 
 select * from different_directories
 
-{{ filter_exceptions(model.name) }}
+{{ filter_exceptions() }}

--- a/models/marts/tests/fct_missing_primary_key_tests.sql
+++ b/models/marts/tests/fct_missing_primary_key_tests.sql
@@ -20,4 +20,4 @@ final as (
 
 select * from final
 
-{{ filter_exceptions(model.name) }}
+{{ filter_exceptions() }}


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes
- [x] new functionality

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Half between bugfix and new functionality. This just simplifies how we filter the exceptions.

This is a breaking change for people who overwrite the definition of `filter_exceptions()` in their own project, so we should release it only in a new minor and not a patch.

It would be good to update the release notes and/or changelog mentioning the breaking change as well.

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
    - [ ] Trino/Starburst
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)