### PR TITLE
Update CI now that core is decoupled

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -12,7 +12,7 @@ then
     then
         pip install "dbt-$1==1.7.1"
     else
-        pip install --pre "dbt-$1" protobuf==4.25
+        pip install --pre "dbt-$1" dbt-core protobuf==4.25
     fi
 fi
 


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
CI is currently broken.

We need to manually install dbt-core now that core and adapters are decoupled