### PR TITLE
Fixes data loading for metrics with `filter` and quoted dates

### DIFF
--- a/integration_tests/models/marts/metrics.yml
+++ b/integration_tests/models/marts/metrics.yml
@@ -36,7 +36,7 @@ metrics:
   # Specify the measure you are creating a proxy for. 
       measure: total_count 
     filter: |
-      {{ Dimension('dim__id') }} > 0
+      {{ Dimension('dim__id') }} > '2023-04-01'
   - name: new_metric_with_window
     label: "New cumulative Metric"
     type: cumulative 

--- a/macros/unpack/get_metric_values.sql
+++ b/macros/unpack/get_metric_values.sql
@@ -9,7 +9,7 @@
     {%- set values = [] -%}
 
     {%- for node in nodes_list -%}
-          
+   
           {%- set values_line = 
             [
             wrap_string_with_quotes(node.unique_id),
@@ -20,7 +20,7 @@
             wrap_string_with_quotes(node.type),
             wrap_string_with_quotes(dbt.escape_single_quotes(node.label)),
             wrap_string_with_quotes(node.package_name),
-            wrap_string_with_quotes(node.filter | tojson),
+            wrap_string_with_quotes(dbt.escape_single_quotes(tojson(node.filter))),
             wrap_string_with_quotes(node.type_params.measure.name),
             wrap_string_with_quotes(node.type_params.measure.alias),
             wrap_string_with_quotes(node.type_params.numerator | tojson),


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->
Fixes #439


## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Fixes data loading issues when using filter in metrics and quoting dates.

TIL that the  [Jinja`tojson` filter](https://jinja.palletsprojects.com/en/2.9.x/templates/#tojson) (e.g. `abc | tojson`) is different and has a slightly different behaviour in comparison with the [`tojson` function in dbt](https://docs.getdbt.com/reference/dbt-jinja-functions/tojson) (e.g. `tojson(abc)`)

Especially, as mentioned in the docs, the Jinja one should be used in HTML contexts only as it is also replacing some characters, like `'`.

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
    - [ ] Trino/Starburst
- [ ] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)