### PR TITLE
Update `fct_chained_views` to only report exceptions, like other fct tables

### DIFF
--- a/models/marts/performance/fct_chained_views_dependencies.sql
+++ b/models/marts/performance/fct_chained_views_dependencies.sql
@@ -16,6 +16,7 @@ final as (
     from all_relationships
     where is_dependent_on_chain_of_views
     and child_resource_type = 'model'
+    and distance > {{ var('chained_views_threshold') }}
 )
 
 select * from final

--- a/models/marts/performance/performance.yml
+++ b/models/marts/performance/performance.yml
@@ -6,11 +6,6 @@ models:
       This returns models dependent on chains of "non-physically-materialized" models (views and ephemerals),
       highlighting potential cases for improving performance by switching the materialization of model(s) within 
       the chain to table or incremental. 
-    columns:
-      - name: distance
-        tests:
-          - dbt_utils.accepted_range:
-              name: valid_chained_views_dependencies
-              max_value: "{{ var('chained_views_threshold') }}"
-              inclusive: false
-              severity: warn
+    tests:
+      - is_empty:
+          severity: warn


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->
N/A

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Not so much a bug fix but this aligns the `fct_` table with the other ones. Those tables normally only show the exceptions/failures.


## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [x] DuckDB
    - [ ] Trino/Starburst
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)