### PR TITLE
Avoid SQL line comments when searching hard coded tables

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -87,3 +87,6 @@ vars:
   # -- Execution variables --
   insert_batch_size: "{{ 500 if target.type in ['athena', 'bigquery'] else 10000 }}"
   max_depth_dag: "{{ 9 if target.type in ['bigquery', 'spark', 'databricks'] else 4 if target.type in ['athena', 'trino'] else -1 }}"
+
+  # -- Code complexity variables --
+  comment_chars: ["--"]

--- a/integration_tests/models/marts/fct_model_6.sql
+++ b/integration_tests/models/marts/fct_model_6.sql
@@ -5,86 +5,89 @@
 }}
 
 select 1 as id 
--- from {{ ref('stg_model_3') }}
 
--- union all 
--- select
---     3 as id
--- from my_db.my_schema.my_table
--- union all 
--- select
---     3 as id
--- from 'my_db'.'my_schema'.'my_table'
--- union all 
--- select
---     3 as id
--- from "my_db"."my_schema"."my_table"
--- union all 
--- select
---     3 as id
--- from `my_db`.`my_schema`.`my_table`
--- union all 
--- select
---     3 as id
--- from [my_db].[my_schema].[my_table]
+-- depends on {{ ref('stg_model_3') }} 
 
--- union all
--- select 
---     4 as id
--- from my_schema.raw_relation_5
--- union all
--- select 
---     4 as id
--- from 'my_schema'.'raw_relation_5' 
--- union all
--- select 
---     4 as id
--- from "my_schema"."raw_relation_5"
--- union all
--- select 
---     4 as id
--- from `my_schema`.`raw_relation_5`
--- union all
--- select 
---     4 as id
--- from [my_schema].[raw_relation_5] 
+{#
+  from {{ ref('stg_model_3') }}   
+  union all 
+  select
+      3 as id
+  from my_db.my_schema.my_table
+  union all 
+  select
+      3 as id
+  from 'my_db'.'my_schema'.'my_table'
+  union all 
+  select
+      3 as id
+  from "my_db"."my_schema"."my_table"
+  union all 
+  select
+      3 as id
+  from `my_db`.`my_schema`.`my_table`
+  union all 
+  select
+      3 as id
+  from [my_db].[my_schema].[my_table]   
+  union all
+  select 
+      4 as id
+  from my_schema.raw_relation_5
+  union all
+  select 
+      4 as id
+  from 'my_schema'.'raw_relation_5' 
+  union all
+  select 
+      4 as id
+  from "my_schema"."raw_relation_5"
+  union all
+  select 
+      4 as id
+  from `my_schema`.`raw_relation_5`
+  union all
+  select 
+      4 as id
+  from [my_schema].[raw_relation_5]    
+  union all
+  select 
+      4 as id
+  from `raw_relation_1` 
+  union all
+  select 
+      4 as id
+  from "raw_relation_2" 
+  union all
+  select 
+      4 as id
+  from [raw_relation_3]  
+  union all
+  select 
+      4 as id
+  from 'raw_relation_4'    
+  union all
+  select
+      4 as id
+  from {{ var("my_table_reference") }}
+  union all
+  select
+      4 as id
+  from {{ var('my_table_reference') }}   
+  union all
+  
+  -- the following is SQL commented so it should be found as a hard coded reference
+--   select
+--       6 as id
+--   from my_db.my_schema.my_table222
+  
+  select
+      5 as id
+  from {{ var("my_table_reference", "table_d") }}
+  union all
+  select
+      5 as id
+  from {{ var('my_table_reference', 'table_d') }}
 
 
--- union all
--- select 
---     4 as id
--- from `raw_relation_1` 
--- union all
--- select 
---     4 as id
--- from "raw_relation_2" 
--- union all
--- select 
---     4 as id
--- from [raw_relation_3]  
--- union all
--- select 
---     4 as id
--- from 'raw_relation_4' 
-
--- union all
--- select
---     4 as id
--- from {{ var("my_table_reference") }}
--- union all
--- select
---     4 as id
--- from {{ var('my_table_reference') }}
-
-
--- union all
--- select
---     5 as id
--- from {{ var("my_table_reference", "table_d") }}
--- union all
--- select
---     5 as id
--- from {{ var('my_table_reference', 'table_d') }}
--- select
---     7 as id
--- from {{ var('my_table_reference', 'table_d') }}
+#}

--- a/macros/find_all_hard_coded_references.sql
+++ b/macros/find_all_hard_coded_references.sql
@@ -14,6 +14,11 @@
         {%- set model_raw_sql = '' -%}
         {%- endif -%}
 
+        {# we remove the comments that start with -- , or other characters configured #}
+        {%- set re = modules.re -%}
+        {%- set comment_chars_match = "(" ~ var('comment_chars') | join("|") ~ ").*" -%}
+        {%- set model_raw_sql_no_comments = re.sub(comment_chars_match, '', model_raw_sql) -%}
+
         {#-
             REGEX Explanations
             
@@ -234,7 +239,7 @@
 
         {%- for regex_name, regex_pattern in from_hard_coded_references.items() -%}
 
-            {%- set all_regex_matches = re.findall(regex_pattern, model_raw_sql) -%}
+            {%- set all_regex_matches = re.findall(regex_pattern, model_raw_sql_no_comments) -%}
                 
                 {%- for match in all_regex_matches -%}
 


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes
- [ ] new functionality
- [x] minor improvement to the current behavior

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->
No issue, but came from [this internal Slack thread](https://dbt-labs.slack.com/archives/C02TRN1757B/p1712242266111429)


## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
This enhances our approach to search for hard coded tables, removing the inline comments (by default `--` but with a new variable to update it)

Being regex, this is not perfect. For example, now we won't find the hard coded references if someone has the following code

```
select '--whatever' from myschema.mytable
```

(e.g. when `--` is not part of a comment)

But I think that this happens much less than people commenting their SQL with `--`

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [x] DuckDB
    - [ ] Trino/Starburst
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)