### PR TITLE
fix pluralality of metric and exposure in rejoining_of_upstream_concepts

### DIFF
--- a/models/marts/dag/fct_rejoining_of_upstream_concepts.sql
+++ b/models/marts/dag/fct_rejoining_of_upstream_concepts.sql
@@ -2,8 +2,8 @@ with all_relationships as (
     select  
         *
     from {{ ref('int_all_dag_relationships') }}
-    where parent_resource_type not in ('exposures', 'metrics')
-    and child_resource_type not in ('exposures', 'metrics')
+    where parent_resource_type not in ('exposure', 'metric')
+    and child_resource_type not in ('exposure', 'metric')
     and not parent_is_excluded
     and not child_is_excluded
 ),


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->
Closes #433 

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Updating the where clause filter for resource_type in rejoining_of_upstream_concepts from `('exposures', 'metrics')` to `('exposure', 'metric')`

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->
Need help running integration tests

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
    - [ ] Trino/Starburst
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)