### PR TITLE
Rename tests: to data_tests:

### DIFF
--- a/docs/ci-check.md
+++ b/docs/ci-check.md
@@ -14,7 +14,7 @@ By default the tests in this package are configured with "warn" severity, we can
 1. Update you project.yml file to override the default severity for all tests in this package:
 
     ```yaml title="dbt_project.yml"
-    tests:
+    data_tests:
       dbt_project_evaluator:
         +severity: "{{ env_var('DBT_PROJECT_EVALUATOR_SEVERITY', 'warn') }}"
     ```

--- a/docs/customization/customization.md
+++ b/docs/customization/customization.md
@@ -14,7 +14,7 @@ disable the corresponding `fct` models as you would any other model in your `dbt
 models:
   dbt_project_evaluator:
     marts:
-      tests:
+      data_tests:
         # disable entire test coverage suite
         +enabled: false
       dag:

--- a/docs/customization/issues-in-log.md
+++ b/docs/customization/issues-in-log.md
@@ -22,6 +22,6 @@ the custom models.
 models:
   - name: my_custom_rule_model
     description: This is my custom project evaluator check 
-    tests:
+    data_tests:
       - dbt_project_evaluator.is_empty
 ```

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -34,7 +34,7 @@ models:
     +materialized: ephemeral
   dbt_project_evaluator:
     marts:
-      tests:
+      data_tests:
         fct_test_coverage:
           # materialize as a table to ensure SQL query runs successfully
           +materialized: table
@@ -43,7 +43,7 @@ models:
           # materialize as a table to ensure SQL query runs successfully
           +materialized: table
 
-tests:
+data_tests:
   dbt_project_evaluator:
     +enabled: false
   dbt_project_evaluator_integration_tests:

--- a/integration_tests/models/dbt_project_evaluator_schema_tests/core.yml
+++ b/integration_tests/models/dbt_project_evaluator_schema_tests/core.yml
@@ -6,7 +6,7 @@ models:
     columns:
       - name: path
         description: unique identifier representing a distinct path from each resource to another resource
-        tests:
+        data_tests:
           - unique
           - not_null 
 
@@ -14,17 +14,17 @@ models:
     description: "This table shows one record for each enabled resource in the graph and information about that resource."
     columns:
       - name: resource_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: on_schema_change
         description: this contains the on_schema_change setting for incremental models. This column was sometimes an empty string, so should be tested to detect regressions
-        tests:
+        data_tests:
           - not_null:
               config:
                 where: resource_type = 'model'
       - name: model_type
-        tests: 
+        data_tests: 
           - dbt_utils.expression_is_true:
               expression: "= 'base'"
               config:
@@ -34,6 +34,6 @@ models:
     description: "This table shows one record for each direct parent/child pair in the graph."
     columns:
       - name: unique_id
-        tests:
+        data_tests:
           - unique
           - not_null

--- a/integration_tests/models/dbt_project_evaluator_schema_tests/graph.yml
+++ b/integration_tests/models/dbt_project_evaluator_schema_tests/graph.yml
@@ -5,7 +5,7 @@ models:
     description: "Staging model from the graph variable, one record per exposure resource relationship (comes from the depends_on field in the graph)."
     columns:
       - name: unique_id
-        tests:
+        data_tests:
           - unique
           - not_null
 
@@ -13,7 +13,7 @@ models:
     description: "Staging model from the graph variable, one record per exposure resource."
     columns:
       - name: unique_id
-        tests:
+        data_tests:
           - unique
           - not_null
 
@@ -21,7 +21,7 @@ models:
     description: "Staging model from the graph variable, one record per metric resource relationship (comes from the depends_on field in the graph)."
     columns:
       - name: unique_id
-        tests:
+        data_tests:
           - unique
           - not_null
 
@@ -29,7 +29,7 @@ models:
     description: "Staging model from the graph variable, one record per metric resource."
     columns:
       - name: unique_id
-        tests:
+        data_tests:
           - unique
           - not_null
 
@@ -37,7 +37,7 @@ models:
     description: "Staging model from the graph variable, one record per direct node relationship (comes from the depends_on field in the graph)."
     columns:
       - name: unique_id
-        tests:
+        data_tests:
           - unique
           - not_null
 
@@ -45,13 +45,13 @@ models:
     description: "Staging model from the graph variable, one record per node (analysis, model, operation, seed, snapshot, test)."
     columns:
       - name: unique_id
-        tests:
+        data_tests:
           - unique
           - not_null
 
   - name: stg_columns
     description: "Staging model from the graph variable, one record per column resource."
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - node_unique_id
@@ -61,7 +61,7 @@ models:
     description: "Staging model from the graph variable, one record per source resource."
     columns:
       - name: unique_id
-        tests:
+        data_tests:
           - unique
           - not_null
 
@@ -69,11 +69,11 @@ models:
     description: "This table parses the folder name variables into a model to help define structure tests"
     columns:
       - name: folder_name
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: model_type 
-        tests:
+        data_tests:
           - accepted_values:
               values: "{{ var('model_types') }}"
 
@@ -82,10 +82,10 @@ models:
     columns:
       - name: unique_id
         description: surrogate key of model_type and prefix value
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: model_type 
-        tests:
+        data_tests:
           - accepted_values:
               values: "{{ var('model_types') }}"

--- a/integration_tests/models/dbt_project_evaluator_schema_tests/tests.yml
+++ b/integration_tests/models/dbt_project_evaluator_schema_tests/tests.yml
@@ -5,6 +5,6 @@ models:
     description: this model creates some initial metrics required for the downstream models related to testing
     columns:
       - name: resource_name
-        tests:
+        data_tests:
           - unique 
           - not_null 

--- a/integration_tests/models/marts/intermediate/_dim_model_7.yml
+++ b/integration_tests/models/marts/intermediate/_dim_model_7.yml
@@ -8,5 +8,5 @@ models:
         data_type: int
         constraints:
           - type: not_null
-        tests:
+        data_tests:
            - unique

--- a/integration_tests/models/staging/source_1/schema.yml
+++ b/integration_tests/models/staging/source_1/schema.yml
@@ -8,10 +8,10 @@ models:
         description: >
           hocus pocus
           pocus hocus
-        tests:
+        data_tests:
           - unique
   - name: stg_model_3
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - id
@@ -19,6 +19,6 @@ models:
   - name: stg_model_2
     columns:
       - name: id 
-        tests:
+        data_tests:
           - unique
           - not_null

--- a/integration_tests/models/staging/staging.yml
+++ b/integration_tests/models/staging/staging.yml
@@ -4,19 +4,19 @@ models:
   - name: stg_model_4
     columns:
       - name: id
-        tests:
+        data_tests:
           - unique
           - not_null
           - relationships:
               to: ref('stg_model_2')
               field: id
       - name: "concat(coalesce('fake_column', ' '),'for_testing')"
-        tests:
+        data_tests:
           - not_null
 
   - name: int_model_4
     columns:
       - name: id
-        tests:
+        data_tests:
           - unique
           - not_null

--- a/integration_tests/models/utils/_utils_models.yml
+++ b/integration_tests/models/utils/_utils_models.yml
@@ -3,6 +3,6 @@ models:
     description: default time spine for metricflow 
     columns:
       - name: date_day
-        tests:
+        data_tests:
           - unique
           - not_null

--- a/integration_tests/seeds/dag/dag_seeds.yml
+++ b/integration_tests/seeds/dag/dag_seeds.yml
@@ -2,7 +2,7 @@ version: 2
 
 seeds:
   - name: test_fct_multiple_sources_joined
-    tests:
+    data_tests:
       - dbt_utils.equality:
           name: equality_fct_multiple_sources_joined
           compare_model: ref('fct_multiple_sources_joined')
@@ -11,7 +11,7 @@ seeds:
             - source_parents
 
   - name: test_fct_direct_join_to_source
-    tests:
+    data_tests:
       - dbt_utils.equality:
           name: equality_fct_direct_join_to_source
           compare_model: ref('fct_direct_join_to_source')
@@ -23,7 +23,7 @@ seeds:
             - distance
 
   - name: test_fct_duplicate_sources
-    tests:
+    data_tests:
       - dbt_utils.equality:
           name: equality_fct_duplicate_sources
           compare_model: ref('fct_duplicate_sources')
@@ -31,19 +31,19 @@ seeds:
             - source_names
 
   - name: test_fct_root_models
-    tests:
+    data_tests:
       - dbt_utils.equality:
           name: equality_fct_root_models
           compare_model: ref('fct_root_models')
 
   - name: test_fct_unused_sources
-    tests:
+    data_tests:
       - dbt_utils.equality:
           name: equality_fct_unused_sources
           compare_model: ref('fct_unused_sources')
 
   - name: test_fct_source_fanout
-    tests:
+    data_tests:
       - dbt_utils.equality:
           name: equality_fct_source_fanout
           compare_model: ref('fct_source_fanout')
@@ -52,7 +52,7 @@ seeds:
             - model_children
 
   - name: test_fct_model_fanout
-    tests:
+    data_tests:
       - dbt_utils.equality:
           name: equality_fct_model_fanout
           compare_model: ref('fct_model_fanout')
@@ -62,7 +62,7 @@ seeds:
             - leaf_children
   
   - name: test_fct_staging_dependent_on_staging
-    tests:
+    data_tests:
       - dbt_utils.equality:
           name: equality_fct_staging_dependent_on_staging
           compare_model: ref('fct_staging_dependent_on_staging')
@@ -73,7 +73,7 @@ seeds:
             - child_model_type
   
   - name: test_fct_rejoining_of_upstream_concepts
-    tests:
+    data_tests:
       - dbt_utils.equality:
           name: equality_fct_rejoining_of_upstream_concepts
           compare_model: ref('fct_rejoining_of_upstream_concepts')
@@ -84,7 +84,7 @@ seeds:
             - is_loop_independent
 
   - name: test_fct_hard_coded_references
-    tests:
+    data_tests:
       - dbt_utils.equality:
           name: equality_fct_hard_coded_references
           compare_model: ref('fct_hard_coded_references')
@@ -93,7 +93,7 @@ seeds:
             - hard_coded_references
 
   - name: test_fct_too_many_joins
-    tests:
+    data_tests:
       - dbt_utils.equality:
           name: equality_fct_too_many_joins
           compare_model: ref('fct_too_many_joins')

--- a/integration_tests/seeds/docs/docs_seeds.yml
+++ b/integration_tests/seeds/docs/docs_seeds.yml
@@ -5,7 +5,7 @@ seeds:
     config:
       tags:
         - docs
-    tests:
+    data_tests:
       - dbt_utils.equality:
           name: equality_fct_undocumented_models
           compare_model: ref('fct_undocumented_models')
@@ -19,7 +19,7 @@ seeds:
         other_documentation_coverage_pct: *float
       tags:
         - docs
-    tests:
+    data_tests:
       - dbt_utils.equality:
           name: equality_fct_documentation_coverage
           compare_model: ref('fct_documentation_coverage')
@@ -36,7 +36,7 @@ seeds:
     config:
       tags:
         - docs
-    tests:
+    data_tests:
       - dbt_utils.equality:
           name: equality_fct_undocumented_source_tables
           compare_model: ref('fct_undocumented_source_tables')
@@ -45,7 +45,7 @@ seeds:
     config:
       tags:
         - docs
-    tests:
+    data_tests:
       - dbt_utils.equality:
           name: equality_fct_undocumented_sources
           compare_model: ref('fct_undocumented_sources')

--- a/integration_tests/seeds/governance/_governance_seeds.yml
+++ b/integration_tests/seeds/governance/_governance_seeds.yml
@@ -2,16 +2,16 @@ version: 2
 
 seeds:  
   - name: test_fct_public_models_without_contract
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('fct_public_models_without_contract')
 
   - name: test_fct_undocumented_public_models
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('fct_undocumented_public_models')
 
   - name: test_fct_exposures_dependent_on_private_models
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('fct_exposures_dependent_on_private_models')

--- a/integration_tests/seeds/performance/performance_seeds.yml
+++ b/integration_tests/seeds/performance/performance_seeds.yml
@@ -2,7 +2,7 @@ version: 2
 
 seeds:
   - name: test_fct_chained_views_dependencies
-    tests:
+    data_tests:
       - dbt_utils.equality:
           name: equality_fct_chained_views_dependencies
           compare_model: ref('fct_chained_views_dependencies')
@@ -12,6 +12,6 @@ seeds:
             - distance
             
   - name: test_fct_exposure_parents_materializations
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('fct_exposure_parents_materializations')

--- a/integration_tests/seeds/structure/structure_seeds.yml
+++ b/integration_tests/seeds/structure/structure_seeds.yml
@@ -2,7 +2,7 @@ version: 2
 
 seeds:
   - name: test_fct_model_directories
-    tests:
+    data_tests:
       - dbt_utils.equality:
           name: equality_fct_model_directories
           compare_model: ref('fct_model_directories')
@@ -11,7 +11,7 @@ seeds:
             - current_file_path
             - change_file_path_to
   - name: test_fct_model_naming_conventions
-    tests:
+    data_tests:
       - dbt_utils.equality:
           name: equality_fct_model_naming_conventions
           compare_model: ref('fct_model_naming_conventions')
@@ -20,7 +20,7 @@ seeds:
             - model_type
             - appropriate_prefixes
   - name: test_fct_source_directories
-    tests:
+    data_tests:
       - dbt_utils.equality:
           name: equality_fct_source_directories
           compare_model: ref('fct_source_directories')
@@ -29,7 +29,7 @@ seeds:
             - current_file_path
             - change_file_path_to
   - name: test_fct_test_directories
-    tests:
+    data_tests:
       - dbt_utils.equality:
           name: equality_fct_test_directories
           compare_model: ref('fct_test_directories')

--- a/integration_tests/seeds/tests/tests_seeds.yml
+++ b/integration_tests/seeds/tests/tests_seeds.yml
@@ -2,7 +2,7 @@ version: 2
 
 seeds:
   - name: test_fct_missing_primary_key_tests
-    tests:
+    data_tests:
       - dbt_utils.equality:
           name: equality_fct_missing_primary_key_tests
           compare_model: ref('fct_missing_primary_key_tests')
@@ -18,7 +18,7 @@ seeds:
         intermediate_test_coverage_pct: *float
         marts_test_coverage_pct: *float
         other_test_coverage_pct: *float
-    tests:
+    data_tests:
       - dbt_utils.equality:
           name: equality_fct_test_coverage
           compare_model: ref('fct_test_coverage')

--- a/models/marts/dag/dag.yml
+++ b/models/marts/dag/dag.yml
@@ -3,60 +3,60 @@ version: 2
 models:
   - name: fct_direct_join_to_source
     description: "This table shows each parent/child relationship where a model has a reference to both a model and a source."
-    tests:
+    data_tests:
       - is_empty
   - name: fct_duplicate_sources
     description: "This table shows each source database location with more than one node in your dbt project."
-    tests:
+    data_tests:
       - is_empty
   - name: fct_marts_or_intermediate_dependent_on_source
     description: "This table shows each parent/child relationship where models in the marts and/or intermediate layer are dependent on source(s)."
-    tests:
+    data_tests:
       - is_empty
   - name: fct_model_fanout
     description: "This table shows all parents with more direct leaf children than the threshold for fanout (determined by variable models_fanout_threshold, default 3)"
-    tests:
+    data_tests:
       - is_empty
   - name: fct_multiple_sources_joined
     description: "This table shows each instance where a model references more than one source."
-    tests:
+    data_tests:
       - is_empty
   - name: fct_rejoining_of_upstream_concepts
     description: >
       "All cases where one of the parent's direct children (child) is ALSO the direct child of ANOTHER one of the 
       parent's direct children (parent_and_child). Only includes cases where the model "in between" the parent and child 
       has NO other downstream dependencies.
-    tests:
+    data_tests:
       - is_empty
   - name: fct_root_models
     description: "This table shows each model with 0 direct parents."
-    tests:
+    data_tests:
       - is_empty
   - name: fct_source_fanout
     description: "This table shows each instance where a source is the direct parent of multiple resources in the DAG."
-    tests:
+    data_tests:
       - is_empty
   - name: fct_staging_dependent_on_marts_or_intermediate
     description: "This table shows each parent/child relationship where models in the staging layer are dependent on models in the marts and/or intermediate layer."
-    tests:
+    data_tests:
       - is_empty
   - name: fct_staging_dependent_on_staging
     description: "This table shows each parent/child relationship where models in the staging layer are dependent on each other."
-    tests:
+    data_tests:
       - is_empty 
   - name: fct_unused_sources
     description: "This table shows each source with 0 children."
-    tests:
+    data_tests:
       - is_empty
   - name: fct_exposure_parents_materializations
     description: "This table shows each direct parent of an exposure that is not materialized as a table or incremental."
-    tests:
+    data_tests:
       - is_empty
   - name: fct_hard_coded_references
     description: "This table shows each model that has hard coded references."
-    tests:
+    data_tests:
       - is_empty
   - name: fct_too_many_joins
     description: "This returns models referencing more than 7 or more dependencies. Per dbt best practices, models should be designed in a way that depend on fewer than 7 joins."
-    tests:
+    data_tests:
       - is_empty

--- a/models/marts/documentation/documentation.yml
+++ b/models/marts/documentation/documentation.yml
@@ -8,7 +8,7 @@ models:
     columns:
       - name: documentation_coverage_pct
         description: the number of models in the project with a description divided by the total number of models in the project
-        tests:
+        data_tests:
           - dbt_utils.accepted_range:
               name: valid_documentation_coverage
               min_value: "{{ var('documentation_coverage_target') }}"
@@ -16,15 +16,15 @@ models:
   - name: fct_undocumented_models
     description: >
       This model contains all models that do not have a description configured in a YML file. 
-    tests:
+    data_tests:
       - is_empty
   - name: fct_undocumented_source_tables
     description: >
       This model contains all source tables that do not have a description configured in a YML file. 
-    tests:
+    data_tests:
       - is_empty
   - name: fct_undocumented_sources
     description: >
       This model contains all sources that do not have a description configured in a YML file. 
-    tests:
+    data_tests:
       - is_empty

--- a/models/marts/governance/governance.yml
+++ b/models/marts/governance/governance.yml
@@ -1,15 +1,15 @@
 models:
   - name: fct_public_models_without_contract
     description: "This table shows each public model that does not have an enforced contract"
-    tests:
+    data_tests:
       - is_empty
 
   - name: fct_undocumented_public_models
     description: "This table shows each public model that does not have both a model level description, and a description for each of the columns in the model"
-    tests:
+    data_tests:
       - is_empty
 
   - name: fct_exposures_dependent_on_private_models
     description: "This table shows each direct relationship between a parent resource and a downstream exposure where the parent resource is not a public model"
-    tests:
+    data_tests:
       - is_empty

--- a/models/marts/performance/performance.yml
+++ b/models/marts/performance/performance.yml
@@ -6,6 +6,6 @@ models:
       This returns models dependent on chains of "non-physically-materialized" models (views and ephemerals),
       highlighting potential cases for improving performance by switching the materialization of model(s) within 
       the chain to table or incremental. 
-    tests:
+    data_tests:
       - is_empty:
           severity: warn

--- a/models/marts/structure/structure.yml
+++ b/models/marts/structure/structure.yml
@@ -3,17 +3,17 @@ version: 2
 models:
   - name: fct_model_directories
     description: This finds all cases where a model is NOT in the appropriate subdirectory.
-    tests:
+    data_tests:
       - is_empty
   - name: fct_model_naming_conventions
     description: This finds all cases where a model does NOT have the appropriate prefix.
-    tests:
+    data_tests:
       - is_empty
   - name: fct_source_directories
     description: This finds all cases where a source definition is NOT in the appropriate subdirectory.
-    tests:
+    data_tests:
       - is_empty
   - name: fct_test_directories
     description: This finds all cases where the yml file for model tests is NOT in the same subdirectory as the corresponding model.
-    tests:
+    data_tests:
       - is_empty

--- a/models/marts/tests/testing.yml
+++ b/models/marts/tests/testing.yml
@@ -6,18 +6,18 @@ models:
     columns:
       - name: test_to_model_ratio
         description: the total number of tests in the project divided by the total number of models in the project
-        # tests:
+        # data_tests:
           # - dbt_utils.accepted_range:
           #     min_value: 1 
           #     severity: warn
       - name: test_coverage_pct
         description: the number of models in the project with at least one test configured divided by the total number of models in the project
-        tests:
+        data_tests:
           - dbt_utils.accepted_range:
               name: valid_test_coverage
               min_value: "{{ var('test_coverage_target') }}"
               severity: warn
   - name: fct_missing_primary_key_tests
     description: this model has one record for every model without unique and not null tests configured on a single column
-    tests:
+    data_tests:
       - is_empty 


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->


## Description & motivation

- changes from `tests` to `data_tests` [due the 1.8 deprecation](https://docs.getdbt.com/docs/build/data-tests#new-data_tests-syntax)

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
    - [ ] Trino/Starburst
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)