### PR TITLE
Add Windows version of each exclusion item to duplicated list

### DIFF
--- a/macros/set_is_excluded.sql
+++ b/macros/set_is_excluded.sql
@@ -18,8 +18,17 @@
     {% endif %}
     
 
+    {#- we duplicate the exclusion list to account for windows directory patterns -#}
+    {%- set exclude_paths_from_project = var('exclude_paths_from_project',[]) -%}
+    {%- set exclude_all_os_paths_from_project = exclude_paths_from_project -%}
+
+    {%- for exclude_paths_pattern in exclude_paths_from_project -%}
+        {%- set windows_path_pattern = exclude_paths_pattern | replace("/", "\\\\") -%}
+        {%- do exclude_all_os_paths_from_project.append(windows_path_pattern) -%}
+    {%- endfor -%}
+
     {#- we exclude the resource if it is from the current project and matches the pattern -#}
-    {%- for exclude_paths_pattern in var('exclude_paths_from_project',[]) -%}
+    {%- for exclude_paths_pattern in exclude_all_os_paths_from_project -%}
         {%- set matched_path = re.search(exclude_paths_pattern, resource_path, re.IGNORECASE) -%}
         {%- if matched_path and resource.package_name == project_name %}
             {% set ns.exclude = true %}

--- a/macros/set_is_excluded.sql
+++ b/macros/set_is_excluded.sql
@@ -22,7 +22,7 @@
     {%- set exclude_all_os_paths_from_project = [] -%}
 
     {%- for exclude_paths_pattern in var('exclude_paths_from_project',[]) -%}
-        {%- set windows_path_pattern = exclude_paths_pattern | replace("/", "\\\\") -%}
+        {%- set windows_path_pattern = exclude_paths_pattern | replace("/", "\\\\\\\\") -%}
         {%- do exclude_all_os_paths_from_project.extend([exclude_paths_pattern, windows_path_pattern]) -%}
     {%- endfor -%}
 

--- a/macros/set_is_excluded.sql
+++ b/macros/set_is_excluded.sql
@@ -19,12 +19,11 @@
     
 
     {#- we duplicate the exclusion list to account for windows directory patterns -#}
-    {%- set exclude_paths_from_project = var('exclude_paths_from_project',[]) -%}
-    {%- set exclude_all_os_paths_from_project = exclude_paths_from_project -%}
+    {%- set exclude_all_os_paths_from_project = [] -%}
 
-    {%- for exclude_paths_pattern in exclude_paths_from_project -%}
+    {%- for exclude_paths_pattern in var('exclude_paths_from_project',[]) -%}
         {%- set windows_path_pattern = exclude_paths_pattern | replace("/", "\\\\") -%}
-        {%- do exclude_all_os_paths_from_project.append(windows_path_pattern) -%}
+        {%- do exclude_all_os_paths_from_project.extend([exclude_paths_pattern, windows_path_pattern]) -%}
     {%- endfor -%}
 
     {#- we exclude the resource if it is from the current project and matches the pattern -#}


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes
- [x] new functionality

## Link to Issue 
Closes #485

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Based on Benoit's [suggestion](https://github.com/dbt-labs/dbt-project-evaluator/issues/485#issuecomment-2305288806), I've:
- created a new list variable containing excluded path patterns and their Windows equivalents
- updated exclusion flagging to loop through this new variable

These changes will allow teams to define a single set of paths to exclude, rather than having to define each path and its Windows equivalent.

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

<img width="943" alt="image" src="https://github.com/user-attachments/assets/45398c60-15c0-4386-8f2d-446d1fac948f">

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
    - [ ] Trino/Starburst
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)

## Testing
I don't have a Windows machine, but worked with a teammate who does to test these changes.

In our private dbt repo, we:
- [x] removed duplicate Windows exclusion path
- [x] repointed project evaluator package to this forked branch
- [x] re-installed package via `dbt deps`
- [x] confirmed that project evaluator succeeded without duplicate Windows exclusion path
```
dbt build --select package:dbt_project_evaluator dbt_project_evaluator_exceptions
```

<img width="726" alt="image" src="https://github.com/user-attachments/assets/9e8cd3ae-6b69-4238-9b9f-be511e53ba47">
