### PR TITLE
Check path in graph rather than env var for os identification

### DIFF
--- a/macros/get_directory_pattern.sql
+++ b/macros/get_directory_pattern.sql
@@ -1,11 +1,19 @@
 -- these macros will read a user’s home environment and detect whether a computer’s operating system is Windows based or Mac/Linux, and display the right directory pattern.
+{% macro is_os_mac_or_linux() %}
+  {% for val in graph.nodes.values() %}
+    {{ return("/" in val.get("original_file_path","")) }}
+  {% endfor %}
+  {{ return(true) }}
+{% endmacro %}
+
 {% macro get_directory_pattern() %}
-  {%- set env_var_home_exists = env_var("HOME", "not_set") != "not_set" -%}
-  {%- set on_mac_or_linux = env_var_home_exists and "\\\\" not in env_var("HOME") -%}
-  {%- if on_mac_or_linux -%}
-    {{ return("/") }}
-  {% else %}
-    {{ return("\\\\") }}
+  {% if execute %}
+    {%- set on_mac_or_linux = dbt_project_evaluator.is_os_mac_or_linux() -%}
+    {%- if on_mac_or_linux -%}
+      {{ return("/") }}
+    {% else %}
+      {{ return("\\\\") }}
+    {% endif %}
   {% endif %}
 {% endmacro %}
  
@@ -15,11 +23,12 @@
 {% endmacro %}
  
 {% macro get_dbtreplace_directory_pattern() %}
-  {%- set env_var_home_exists = env_var("HOME", "not_set") != "not_set" -%}
-  {%- set on_mac_or_linux = env_var_home_exists and "\\\\" not in env_var("HOME") -%}
-  {%- if on_mac_or_linux -%}
-    {{ dbt.replace("file_path", "regexp_replace(file_path,'.*/','')", "''") }}
-  {% else %}
-    {{ dbt.replace("file_path", "regexp_replace(file_path,'.*\\\\\\\\','')", "''") }}
+  {% if execute %}
+    {%- set on_mac_or_linux = dbt_project_evaluator.is_os_mac_or_linux() -%}
+    {%- if on_mac_or_linux -%}
+      {{ dbt.replace("file_path", "regexp_replace(file_path,'.*/','')", "''") }}
+    {% else %}
+      {{ dbt.replace("file_path", "regexp_replace(file_path,'.*\\\\\\\\','')", "''") }}
+    {% endif %}
   {% endif %}
 {% endmacro %} 

--- a/macros/get_directory_pattern.sql
+++ b/macros/get_directory_pattern.sql
@@ -1,7 +1,7 @@
 -- these macros will read a user’s home environment and detect whether a computer’s operating system is Windows based or Mac/Linux, and display the right directory pattern.
 {% macro is_os_mac_or_linux() %}
   {% for val in graph.nodes.values() %}
-    {{ return("/" in val.get("original_file_path","")) }}
+    {{ return("\\" not in val.get("original_file_path","")) }}
   {% endfor %}
   {{ return(true) }}
 {% endmacro %}


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->
Fixes #484


## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Instead of checking for `/` or `\` in an env var, we check for those in the filepaths of the graph.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [x] DuckDB
    - [ ] Trino/Starburst
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)