### PR TITLE
Add dropped fields to primary key tests table

### DIFF
--- a/models/marts/tests/fct_missing_primary_key_tests.sql
+++ b/models/marts/tests/fct_missing_primary_key_tests.sql
@@ -1,7 +1,7 @@
-with 
+with
 
 tests as (
-    select * from {{ ref('int_model_test_summary') }} 
+    select * from {{ ref('int_model_test_summary') }}
     where resource_type in
     (
         {% for resource_type in var('enforced_primary_key_node_types') %}'{{ resource_type }}'{% if not loop.last %},{% endif %}
@@ -11,8 +11,13 @@ tests as (
 
 final as (
 
-    select 
-        resource_name, is_primary_key_tested, number_of_tests_on_model, number_of_constraints_on_model
+    select
+        resource_name,
+        resource_type,
+        model_type,
+        is_primary_key_tested,
+        number_of_tests_on_model,
+        number_of_constraints_on_model
     from tests
     where not(is_primary_key_tested)
 


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->
Closes #493 


## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
This fixes a bug as described in #493 

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->
Unable to run locally

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [x] Redshift
    - [ ] Snowflake
    - [x] Databricks
    - [ ] DuckDB
    - [ ] Trino/Starburst
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)