### PR TITLE
add missing exceptions filter to fct_duplicate_sources

### DIFF
--- a/models/marts/dag/fct_duplicate_sources.sql
+++ b/models/marts/dag/fct_duplicate_sources.sql
@@ -27,3 +27,5 @@ source_duplicates as (
 )
 
 select * from source_duplicates
+
+{{ filter_exceptions() }}


### PR DESCRIPTION
This is a:
- [X] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 

Closes #498 


## Description & motivation

it broke and it should be fixed

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
    - [ ] Trino/Starburst
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)