### PR TITLE
Fix `print_dbt_project_evaluator_issues` for BigQuery

### DIFF
--- a/macros/on-run-end/print_dbt_project_evaluator_issues.sql
+++ b/macros/on-run-end/print_dbt_project_evaluator_issues.sql
@@ -25,15 +25,10 @@
         {{ print("\n-- " ~ result.node.fqn | join(".") ~ " --") }}
 
         {% set unique_id_model_checked = result.node.depends_on.nodes[0] %}
-
         {% set model_details = graph["nodes"][unique_id_model_checked] %}
-        {% set name_model_checked = model_details.alias %}
-        {% set model_schema = quote ~ model_details.schema ~ quote %}
-        {% set model_database = quote ~ model_details.database ~ quote if model_details.database  else None %}
-        {% set db_schema = model_database ~ "." ~ model_schema if model_database else model_schema %}
 
         {% set sql_statement %}
-        select * from {{ model_details['relation_name'] }}
+        select * from {{ model_details.relation_name }}
         {% endset %}
 
         {% set query_results = run_query(sql_statement) %}

--- a/macros/on-run-end/print_dbt_project_evaluator_issues.sql
+++ b/macros/on-run-end/print_dbt_project_evaluator_issues.sql
@@ -33,7 +33,7 @@
         {% set db_schema = model_database ~ "." ~ model_schema if model_database else model_schema %}
 
         {% set sql_statement %}
-        select * from {{db_schema}}.{{name_model_checked}}
+        select * from {{ model_details['relation_name'] }}
         {% endset %}
 
         {% set query_results = run_query(sql_statement) %}


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 

Closes #502.

## Description & motivation

The `print_dbt_project_evaluator_issues` macro doesn't reference the resource correctly on BigQuery. Specifically, it misses the backticks in `select ... from `project.dataset.table``. This PR fixes it. 

Unsure how to test this without re-working the macro quite substantially. AFAICT, no existing tests either. Open to discussion.

## Integration Test Screenshot

See attached logs: 
* [bigquery.txt](https://github.com/user-attachments/files/17245622/bigquery.txt)
* [postgres.txt](https://github.com/user-attachments/files/17245623/postgres.txt)


## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
    - [ ] Trino/Starburst
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)