### PR TITLE
Add source freshness to the list

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -19,8 +19,9 @@ hide:
 |Modeling                                      |[Root Models](../rules/modeling/#root-models)                                                                          |`fct_root_models`|
 |Modeling                                      |[Staging Models Dependent on Downstream Models](../rules/modeling/#staging-models-dependent-on-downstream-models)      |`fct_staging_dependent_on_marts_or_intermediate`|
 |Modeling                                      |[Unused Sources](../rules/modeling/#unused-sources)                                                                    |`fct_unused_sources`|
-|Modeling                                      |[Models with Too Many Joins](../rules/modeling/#models-with-too-many-joins)                                           |`fct_too_many_joins`|
+|Modeling                                      |[Models with Too Many Joins](../rules/modeling/#models-with-too-many-joins)                                            |`fct_too_many_joins`|
 |Testing                                       |[Missing Primary Key Tests](../rules/testing/#missing-primary-key-tests)                                               |`fct_missing_primary_key_tests`|
+|Testing                                       |[Missing Source Freshness](../rules/testing/#missing-source-freshness)                                                 |`fct_sources_without_freshness`|
 |Testing                                       |[Test Coverage](../rules/testing/#test-coverage)                                                                       |`fct_test_coverage`|
 |Documentation                                 |[Undocumented Models](../rules/documentation/#undocumented-models)                                                     |`fct_undocumented_models`|
 |Documentation                                 |[Documentation Coverage](../rules/documentation/#documentation-coverage)                                               |`fct_documentation_coverage`|


### PR DESCRIPTION
This is a:
- [X] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->


## Description & motivation
<!---
fct_sources_without_freshness is used in the coalesce workshop but is missing from the list. It's the first error listed, so it would be best if it could be found in the docs.
-->

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
    - [ ] Trino/Starburst
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)