### PR TITLE
remove BQ macro shim

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,7 +2,7 @@ name: 'dbt_project_evaluator'
 version: '1.0.0'
 config-version: 2
 
-require-dbt-version: [">=1.6.0-rc1", "<2.0.0"]
+require-dbt-version: [">=1.8.0", "<2.0.0"]
 
 model-paths: ["models"]
 analysis-paths: ["analysis"]

--- a/macros/wrap_string_with_quotes.sql
+++ b/macros/wrap_string_with_quotes.sql
@@ -5,10 +5,3 @@
     {{ dbt.string_literal(str) }}
   {% endif %}
 {% endmacro %}
-
-{#
-  To be removed when https://github.com/dbt-labs/dbt-bigquery/pull/1089 is merged
-#}
-{% macro bigquery__string_literal(value) -%}
-  '''{{ value }}'''
-{%- endmacro %}


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
Closes #449


## Description & motivation
Removing our BQ shim now that the fix landed in core. 

this landed in `dbt-bigquery 1.8.0` and above, so requires pinning the version in this package accordingly

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [x] DuckDB
    - [ ] Trino/Starburst
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)