### PR TITLE
make the list-agg columns conditionally tested

### DIFF
--- a/integration_tests/seeds/dag/dag_seeds.yml
+++ b/integration_tests/seeds/dag/dag_seeds.yml
@@ -8,7 +8,7 @@ seeds:
           compare_model: ref('fct_multiple_sources_joined')
           compare_columns:
             - child
-            - source_parents
+            - "{{ 'source_parents' if target.type != 'databricks' else 'child' }}"
 
   - name: test_fct_direct_join_to_source
     tests:
@@ -49,7 +49,7 @@ seeds:
           compare_model: ref('fct_source_fanout')
           compare_columns:
             - parent
-            - model_children
+            - "{{ 'model_children' if target.type != 'databricks' else 'parent' }}"
 
   - name: test_fct_model_fanout
     tests:
@@ -59,7 +59,7 @@ seeds:
           compare_columns:
             - parent
             - parent_model_type
-            - leaf_children
+            - "{{ 'leaf_children' if target.type != 'databricks' else 'parent_model_type' }}"
   
   - name: test_fct_staging_dependent_on_staging
     tests:

--- a/integration_tests/seeds/structure/structure_seeds.yml
+++ b/integration_tests/seeds/structure/structure_seeds.yml
@@ -18,7 +18,7 @@ seeds:
           compare_columns:
             - resource_name
             - model_type
-            - appropriate_prefixes
+            - "{{ 'appropriate_prefixes' if target.type != 'databricks' else 'model_type' }}"
   - name: test_fct_source_directories
     tests:
       - dbt_utils.equality:


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 

DBX tests are failing in main because there is no support on Databricks for an `order_by` clause in the `dbt.listagg` macro, so we can't guarantee the order of the array of values in models where we report a list of violations within a single record. 

Example: 

```bash
 dbt show -s fct_source_fanout -t databricks --output json     
14:25:37  Running with dbt=1.8.8
14:25:38  Found 70 models, 72 data tests, 28 seeds, 8 sources, 1 exposure, 2 metrics, 779 macros, 1 semantic model
14:25:41  {
  "node": "fct_source_fanout",
  "show": [
    {
      "parent": "source_1.table_2",
      "model_children": "stg_model_2, int_model_4"
    },
    {
      "parent": "source_1.table_1",
      "model_children": "stg_model_2, stg_model_1"
    }
  ]
}
(dpe) 
dbt-project-evaluator/integration_tests on  dbx-test-fixes via (dpe) on ☁️  dev-admin (us-east-1) on ☁️   took 5s 
❯ dbt show -s test_fct_source_fanout -t databricks --output json
14:25:47  Running with dbt=1.8.8
14:25:48  Found 70 models, 72 data tests, 28 seeds, 8 sources, 1 exposure, 2 metrics, 779 macros, 1 semantic model
14:25:55  {
  "node": "test_fct_source_fanout",
  "show": [
    {
      "parent": "source_1.table_2",
      "model_children": "int_model_4, stg_model_2"
    },
    {
      "parent": "source_1.table_1",
      "model_children": "stg_model_1, stg_model_2"
    }
  ]
}
```

You can see the values are reversed, but identical. 

This PR makes those columns conditional in our test configuration so that they are tested for all other adapters except DBX. 

Since CI is off, i am running these tests locally!

## Integration Test Screenshot

<img width="864" alt="image" src="https://github.com/user-attachments/assets/71ec8aa6-9878-45fd-bdaf-12e311da40fe">


## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [x] Redshift
    - [x] Snowflake
    - [x] Databricks
    - [x] DuckDB
    - [ ] Trino/Starburst
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)