### PR TITLE
Update CI trigger to run off forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
     push:
         branches:
             - main
-    pull_request:
+    pull_request_target:
     workflow_dispatch:
 
 


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->

## Description & motivation

PRs from forks will fail CI because the PR trigger is `pull_request` so they do not have access to teh repo vars that are needed since the workflow runs in the context of the fork.  

Update to trigger off `pull_request_target` and the workflow runs in the context of the base branch (this repo).

Will not require a release as this only affects local repo CI.

## Checklist
- [ ] ~~I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)~~
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
    - [ ] Trino/Starburst
- [ ] ~~I have updated the README.md (if applicable)~~
- [ ] ~~I have added tests & descriptions to my models (and macros if applicable)~~