### PR TITLE
Update docs/customization/excluding-packages-and-paths.md

### DIFF
--- a/docs/customization/excluding-packages-and-paths.md
+++ b/docs/customization/excluding-packages-and-paths.md
@@ -39,7 +39,7 @@ vars:
 
 ```yaml title="dbt_project.yml"
 vars:
-  exclude_paths_from_project: ["/models/legacy/"]
+  exclude_paths_from_project: ["models/legacy/"]
 ```
 
 ### Example to exclude both a package and models/sources in 2 different paths
@@ -47,7 +47,7 @@ vars:
 ```yaml title="dbt_project.yml"
 vars:
   exclude_packages: ["upstream_package"]
-  exclude_paths_from_project: ["/models/legacy/", "/my_date_spine.sql"]
+  exclude_paths_from_project: ["models/legacy/", "/my_date_spine.sql"]
 ```
 
 ## Tips and tricks


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->


## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
The example provided for excluding an entire models directory will fail on any project that is following best practices for project layout.

The inclusion of a leading "/" before "models" requires the models directory to be contained within a sub-directory below the location of `dbt_project.yml` file; under the best practices layout of a dbt project the models directory and the `dbt_project.yml` file reside on the same level.  The regex uses relative paths from the location of the `dbt_project.yml` file.

I was trying to following the example to exclude a folder of legacy models, but the models kept appearing in the evaluation outputs.  Eventually I realized that the leading "/" before "models" was causing the issue.  I hope to prevent others from repeating my mistake.



## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [x] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
    - [ ] Trino/Starburst
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)