### PR TITLE
Move source freshness under config

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,7 +2,7 @@ name: 'dbt_project_evaluator'
 version: '1.0.0'
 config-version: 2
 
-require-dbt-version: [">=1.8.0", "<2.0.0"]
+require-dbt-version: [">=1.9.0", "<2.0.0"]
 
 model-paths: ["models"]
 analysis-paths: ["analysis"]

--- a/integration_tests/models/staging/source_1/source.yml
+++ b/integration_tests/models/staging/source_1/source.yml
@@ -4,8 +4,9 @@ sources:
   - name: source_1
     description: this is source 1.
     schema: real_schema
-    freshness: # default freshness
-      warn_after: {count: 12, period: hour}
+    config:
+      freshness: # default freshness
+        warn_after: {count: 12, period: hour}
     # database: real_database
     tables:
       - name: table_1
@@ -16,7 +17,8 @@ sources:
       - name: table_2
       - name: table_4
       - name: table_5
-        freshness: null
+        config:
+          freshness: null
       - name: raw_table_5
         identifier: table_5
 

--- a/macros/unpack/get_source_values.sql
+++ b/macros/unpack/get_source_values.sql
@@ -24,8 +24,8 @@
               "cast(" ~ dbt_project_evaluator.is_not_empty_string(node.description) | trim ~ " as " ~ dbt.type_boolean() ~ ")",
               "cast(" ~ node.config.enabled ~ " as " ~ dbt.type_boolean() ~ ")",
               wrap_string_with_quotes(node.loaded_at_field | replace("'", "_")),
-              "cast(" ~ ((node.freshness != None) and (dbt_project_evaluator.is_not_empty_string(node.freshness.warn_after.count) 
-                or dbt_project_evaluator.is_not_empty_string(node.freshness.error_after.count))) | trim ~ " as boolean)",
+              "cast(" ~ ((node.config.freshness != None) and (dbt_project_evaluator.is_not_empty_string(node.config.freshness.warn_after.count) 
+                or dbt_project_evaluator.is_not_empty_string(node.config.freshness.error_after.count))) | trim ~ " as boolean)",
               wrap_string_with_quotes(node.database),
               wrap_string_with_quotes(node.schema),
               wrap_string_with_quotes(node.package_name),


### PR DESCRIPTION
Starting in 1.10, dbt Core is issuing deprecating warnings for moving `freshness` under `config` ([issue](https://github.com/dbt-labs/dbt-core/issues/11506)).

We are backporting the ability to set `freshness` under `config` to 1.9 ([issue](https://github.com/dbt-labs/dbt-core/issues/11681)).

This PR:
- moves source `freshness` under config
- updates required dbt version to 1.9