### PR TITLE
Escape \ in columns descriptions

### DIFF
--- a/integration_tests/models/marts/intermediate/_dim_model_7.yml
+++ b/integration_tests/models/marts/intermediate/_dim_model_7.yml
@@ -5,6 +5,7 @@ models:
         enforced: true
     columns:
       - name: id
+        description: A multiline description containing example values that might\nbe held in this column. These examples include one with a format like something\Something\Another\Thing
         data_type: "{{ 'UInt8' if target.type in ['clickhouse'] else 'int' }}"
         constraints:
           - type: not_null

--- a/integration_tests/models/staging/source_1/source.yml
+++ b/integration_tests/models/staging/source_1/source.yml
@@ -12,7 +12,7 @@ sources:
         description: this is table 1.
         columns:
           - name: my_column
-            description: description for my source column
+            description: description for my source column with weird chars like \Something\Another\Thing 
       - name: table_2
       - name: table_4
       - name: table_5

--- a/macros/unpack/get_column_values.sql
+++ b/macros/unpack/get_column_values.sql
@@ -22,7 +22,7 @@
                     [
                         wrap_string_with_quotes(node.unique_id),
                         wrap_string_with_quotes(dbt.escape_single_quotes(column.name)),
-                        wrap_string_with_quotes(dbt.escape_single_quotes(column.description)),
+                        wrap_string_with_quotes(dbt.escape_single_quotes(column.description) | replace("\\","\\\\") ),
                         wrap_string_with_quotes(dbt.escape_single_quotes(column.data_type)),
                         wrap_string_with_quotes(dbt.escape_single_quotes(tojson(column.constraints))),
                         column.constraints | selectattr('type', 'equalto', 'not_null') | list | length > 0,


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->
Closes #529

I could replicate the issue without the fix for the macro
