### PR TITLE
Change order of escaping backslash and quote

### DIFF
--- a/macros/unpack/get_column_values.sql
+++ b/macros/unpack/get_column_values.sql
@@ -22,7 +22,7 @@
                     [
                         wrap_string_with_quotes(node.unique_id),
                         wrap_string_with_quotes(dbt.escape_single_quotes(column.name)),
-                        wrap_string_with_quotes(dbt.escape_single_quotes(column.description) | replace("\\","\\\\") ),
+                        wrap_string_with_quotes(dbt.escape_single_quotes(column.description | replace("\\","\\\\"))),
                         wrap_string_with_quotes(dbt.escape_single_quotes(column.data_type)),
                         wrap_string_with_quotes(dbt.escape_single_quotes(tojson(column.constraints))),
                         column.constraints | selectattr('type', 'equalto', 'not_null') | list | length > 0,


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->
Fix for #541 

The issue is due to a bugfix released yesterday. But now, description with `'` in them are failing due to DBX/Spark escaping those not with `''` but with `\'`.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
    - [ ] Databricks
    - [x] DuckDB
    - [ ] Trino/Starburst
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)