### PR TITLE
fix return() in calculate_number_lines.sql

### DIFF
--- a/macros/calculate_number_lines.sql
+++ b/macros/calculate_number_lines.sql
@@ -12,7 +12,7 @@
         {%- set model_raw_sql = '' -%}
         {%- endif -%}
 
-        {{ return(model_raw_sql.count("\n")) + 1 }}
+        {{ return(model_raw_sql.count("\n") + 1) }}
 
     {% endif %}
 


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->


## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
    - [ ] Trino/Starburst
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)