### PR TITLE
ci: use reusable workflows from dbt-labs/dbt-package-testing@v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,64 +19,41 @@ on:
 permissions:
     contents: read
 
-env:
-    PYTHON_VERSION: "3.11"
-
 jobs:
-    run-tests:
-        runs-on: ubuntu-latest
-        environment: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) && 'cloud-tests' || '' }}
-        strategy:
-            fail-fast: false
-            matrix:
-                adapter: [snowflake, bigquery, redshift, databricks]
-
-        steps:
-            - name: "Checkout PR code"
-              uses: actions/checkout@v4
-              with:
-                  # For pull_request_target, we must explicitly checkout the PR head
-                  ref: ${{ github.event.pull_request.head.sha || github.ref }}
-
-            - name: "Set up Python ${{ env.PYTHON_VERSION }}"
-              uses: actions/setup-python@v5
-              with:
-                  python-version: ${{ env.PYTHON_VERSION }}
-
-            - name: "Install dbt-${{ matrix.adapter }}"
-              run: |
-                  python -m pip install --upgrade pip
-                  pip install dbt-${{ matrix.adapter }}
-
-            - name: "Install tox"
-              run: |
-                  pip install tox
-
-            - name: "Run integration tests on ${{ matrix.adapter }}"
-              run: |
-                  tox -e dbt_integration_${{ matrix.adapter }}
-              env:
-                # snowflake
-                SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
-                SNOWFLAKE_USER: ${{ vars.SNOWFLAKE_USER }}
-                DBT_ENV_SECRET_SNOWFLAKE_PASS: ${{ secrets.SNOWFLAKE_PASS }}
-                SNOWFLAKE_ROLE: ${{ vars.SNOWFLAKE_ROLE }}
-                SNOWFLAKE_DATABASE: ${{ vars.SNOWFLAKE_DATABASE }}
-                SNOWFLAKE_WAREHOUSE: ${{ vars.SNOWFLAKE_WAREHOUSE }}
-                SNOWFLAKE_SCHEMA: "dbt_project_evaluator_integration_tests_snowflake_${{ github.run_number }}"
-                # bigquery
-                BIGQUERY_PROJECT: ${{ vars.BIGQUERY_PROJECT }}
-                BIGQUERY_KEYFILE_JSON: ${{ secrets.BIGQUERY_KEYFILE_JSON }}
-                BIGQUERY_SCHEMA: "dpe_integration_tests_bigquery_${{ github.run_number }}"
-                # redshift
-                REDSHIFT_HOST: ${{ vars.REDSHIFT_HOST }}
-                REDSHIFT_USER: ${{ vars.REDSHIFT_USER }}
-                DBT_ENV_SECRET_REDSHIFT_PASS: ${{ secrets.REDSHIFT_PASS }}
-                REDSHIFT_DATABASE: ${{ vars.REDSHIFT_DATABASE }}
-                REDSHIFT_SCHEMA: "dpe_integration_tests_redshift_${{ github.run_number }}"
-                REDSHIFT_PORT: 5439
-                # databricks
-                DATABRICKS_HOST: ${{ vars.DATABRICKS_HOST }}
-                DATABRICKS_HTTP_PATH: ${{ vars.DATABRICKS_HTTP_PATH }}
-                DBT_ENV_SECRET_DATABRICKS_TOKEN: ${{ secrets.DBT_ENV_SECRET_DATABRICKS_TOKEN }}
-                DATABRICKS_SCHEMA: "integration_tests_databricks_${{ github.run_number }}"
+    core-tests:
+        uses: dbt-labs/dbt-package-testing/.github/workflows/run_tox.yml@v2
+        with:
+            # Adapters are read from supported_adapters.env if not specified here
+            adapters: "snowflake,bigquery,redshift,databricks"
+            # For pull_request_target: require environment approval for fork PRs
+            environment: >-
+                ${{ github.event_name == 'pull_request_target'
+                    && github.event.pull_request.head.repo.full_name != github.repository
+                    && 'cloud-tests' || '' }}
+            # For pull_request_target: checkout the PR head, not the base branch
+            ref: ${{ github.event.pull_request.head.sha || '' }}
+            # snowflake
+            SNOWFLAKE_USER: ${{ vars.SNOWFLAKE_USER }}
+            SNOWFLAKE_ROLE: ${{ vars.SNOWFLAKE_ROLE }}
+            SNOWFLAKE_DATABASE: ${{ vars.SNOWFLAKE_DATABASE }}
+            SNOWFLAKE_WAREHOUSE: ${{ vars.SNOWFLAKE_WAREHOUSE }}
+            SNOWFLAKE_SCHEMA: "dbt_project_evaluator_integration_tests_snowflake_${{ github.run_number }}"
+            # bigquery
+            BIGQUERY_PROJECT: ${{ vars.BIGQUERY_PROJECT }}
+            BIGQUERY_SCHEMA: "dpe_integration_tests_bigquery_${{ github.run_number }}"
+            # redshift
+            REDSHIFT_HOST: ${{ vars.REDSHIFT_HOST }}
+            REDSHIFT_USER: ${{ vars.REDSHIFT_USER }}
+            REDSHIFT_DATABASE: ${{ vars.REDSHIFT_DATABASE }}
+            REDSHIFT_SCHEMA: "dpe_integration_tests_redshift_${{ github.run_number }}"
+            REDSHIFT_PORT: "5439"
+            # databricks
+            DATABRICKS_SCHEMA: "integration_tests_databricks_${{ github.run_number }}"
+            DATABRICKS_HOST: ${{ vars.DATABRICKS_HOST }}
+            DATABRICKS_HTTP_PATH: ${{ vars.DATABRICKS_HTTP_PATH }}
+        secrets:
+            SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+            DBT_ENV_SECRET_SNOWFLAKE_PASS: ${{ secrets.SNOWFLAKE_PASS }}
+            BIGQUERY_KEYFILE_JSON: ${{ secrets.BIGQUERY_KEYFILE_JSON }}
+            DBT_ENV_SECRET_REDSHIFT_PASS: ${{ secrets.REDSHIFT_PASS }}
+            DBT_ENV_SECRET_DATABRICKS_TOKEN: ${{ secrets.DBT_ENV_SECRET_DATABRICKS_TOKEN }}

--- a/.github/workflows/fusion.yml
+++ b/.github/workflows/fusion.yml
@@ -1,5 +1,5 @@
 # **what?**
-# Run tests using dbt Fusion against Snowflake
+# Run tests using dbt Fusion against supported adapters
 
 # **why?**
 # To ensure that dbt-project-evaluator works as expected with dbt Fusion
@@ -9,9 +9,8 @@
 # On every PR, and every push to main and when manually triggered
 
 # **note**
-# Currently only Snowflake is tested with Fusion. Additional adapters can be
-# added to the matrix as Fusion support expands. Credentials are shared with
-# the existing dbt-core Snowflake tests.
+# DuckDB runs first as a quick check that does not require cloud credentials.
+# Cloud adapter tests use the reusable workflow from dbt-labs/dbt-package-testing.
 
 name: Fusion Integration Tests
 
@@ -22,14 +21,15 @@ on:
     pull_request_target:
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 env:
     PYTHON_VERSION: "3.11"
 
 jobs:
     run-duckdb-tests:
         runs-on: ubuntu-latest
-        permissions:
-            contents: read
 
         steps:
             - name: "Checkout PR code"
@@ -60,51 +60,23 @@ jobs:
               run: |
                   tox -e dbt_integration_fusion_duckdb
 
-    run-cloud-tests:
+    fusion-tests:
         needs: run-duckdb-tests
-        runs-on: ubuntu-latest
-        environment: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) && 'cloud-tests' || '' }}
-        strategy:
-            fail-fast: false
-            matrix:
-                # Only Snowflake for now - add more adapters here as Fusion support expands
-                adapter: [snowflake]
-
-        steps:
-            - name: "Checkout PR code"
-              uses: actions/checkout@v4
-              with:
-                  # For pull_request_target, we must explicitly checkout the PR head
-                  ref: ${{ github.event.pull_request.head.sha || github.ref }}
-
-            - name: "Set up Python ${{ env.PYTHON_VERSION }}"
-              uses: actions/setup-python@v5
-              with:
-                  python-version: ${{ env.PYTHON_VERSION }}
-
-            - name: "Install dbt Fusion"
-              run: |
-                  curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh
-                  echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-            - name: "Verify Fusion installation"
-              run: |
-                  dbt --version
-
-            - name: "Install tox"
-              run: |
-                  python -m pip install --upgrade pip
-                  pip install tox
-
-            - name: "Run Fusion integration tests on ${{ matrix.adapter }}"
-              run: |
-                  tox -e dbt_integration_fusion_${{ matrix.adapter }}
-              env:
-                # snowflake
-                SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
-                SNOWFLAKE_USER: ${{ vars.SNOWFLAKE_USER }}
-                DBT_ENV_SECRET_SNOWFLAKE_PASS: ${{ secrets.SNOWFLAKE_PASS }}
-                SNOWFLAKE_ROLE: ${{ vars.SNOWFLAKE_ROLE }}
-                SNOWFLAKE_DATABASE: ${{ vars.SNOWFLAKE_DATABASE }}
-                SNOWFLAKE_WAREHOUSE: ${{ vars.SNOWFLAKE_WAREHOUSE }}
-                SNOWFLAKE_SCHEMA: "fusion_integration_tests_${{ matrix.adapter }}_${{ github.run_number }}"
+        uses: dbt-labs/dbt-package-testing/.github/workflows/run_tox_fusion.yml@v2
+        with:
+            # Only Snowflake for now - add more adapters here as Fusion support expands
+            adapters: "snowflake"
+            environment: >-
+                ${{ github.event_name == 'pull_request_target'
+                    && github.event.pull_request.head.repo.full_name != github.repository
+                    && 'cloud-tests' || '' }}
+            ref: ${{ github.event.pull_request.head.sha || '' }}
+            # snowflake
+            SNOWFLAKE_USER: ${{ vars.SNOWFLAKE_USER }}
+            SNOWFLAKE_ROLE: ${{ vars.SNOWFLAKE_ROLE }}
+            SNOWFLAKE_DATABASE: ${{ vars.SNOWFLAKE_DATABASE }}
+            SNOWFLAKE_WAREHOUSE: ${{ vars.SNOWFLAKE_WAREHOUSE }}
+            SNOWFLAKE_SCHEMA: "fusion_integration_tests_snowflake_${{ github.run_number }}"
+        secrets:
+            SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+            DBT_ENV_SECRET_SNOWFLAKE_PASS: ${{ secrets.SNOWFLAKE_PASS }}

--- a/integration_tests_sl/models/marts/intermediate/_dim_model_7.yml
+++ b/integration_tests_sl/models/marts/intermediate/_dim_model_7.yml
@@ -17,6 +17,7 @@ models:
         dimension:
           type: categorical
       - name: date_day
+        data_type: date
         dimension:
           type: time
         granularity: day

--- a/integration_tests_sl/models/marts/intermediate/dim_model_7.sql
+++ b/integration_tests_sl/models/marts/intermediate/dim_model_7.sql
@@ -6,4 +6,7 @@
 }}
 
 -- {{ ref('int_model_5') }}
-select * from {{ ref('stg_model_4') }}
+select
+    *,
+    cast('2024-01-01' as date) as date_day
+from {{ ref('stg_model_4') }}

--- a/run_fusion_tests.sh
+++ b/run_fusion_tests.sh
@@ -15,7 +15,9 @@ dbt build -x --target $1 --full-refresh --static-analysis=off --vars "$FUSION_VA
 echo "Running Fusion tests for the second project"
 cd ../integration_tests_2
 dbt deps --target $1 || exit 1
-dbt seed --full-refresh --target $1 --static-analysis=off --vars "$FUSION_VARS" || exit 1
+# Skip `dbt seed` under Fusion: it mis-resolves the package seed path with a
+# doubled `dbt_packages/dbt_project_evaluator/...` prefix. Not needed here
+# because this project runs `dbt run` only (no tests → no exceptions lookup).
 dbt run -x --target $1 --full-refresh --static-analysis=off --vars "$FUSION_VARS" || exit 1
 
 echo "Running Fusion tests for the SL project (new semantic layer spec)"


### PR DESCRIPTION
## Summary
- Replace inline integration-test jobs in `ci.yml` and `fusion.yml` with calls to the reusable workflows `run_tox.yml@v2` and `run_tox_fusion.yml@v2` from [dbt-labs/dbt-package-testing](https://github.com/dbt-labs/dbt-package-testing).
- Preserve the existing schema naming (`dbt_project_evaluator_integration_tests_snowflake_...`, `dpe_integration_tests_bigquery_...`, etc.) and secret mappings (`SNOWFLAKE_PASS` → `DBT_ENV_SECRET_SNOWFLAKE_PASS`, `REDSHIFT_PASS` → `DBT_ENV_SECRET_REDSHIFT_PASS`).
- Keep the standalone `run-duckdb-tests` Fusion job as a quick credential-free check that gates the cloud Fusion job.
- Keep `pull_request_target` + `cloud-tests` environment gating for fork PRs and PR-head checkout behavior.

The project previously referenced this reusable workflow but it was not functioning (couldn't use `pull_request_target`); the upstream reusable workflow has since been updated to support that trigger.

## Test plan
- [ ] Core integration tests pass for snowflake, bigquery, redshift, databricks
- [ ] Fusion duckdb job runs without cloud credentials
- [ ] Fusion snowflake cloud job runs after duckdb job succeeds
- [ ] Fork PR triggers `cloud-tests` environment approval gate