### PR TITLE
fix: pin dbt-package-testing reusable workflows to commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
     core-tests:
-        uses: dbt-labs/dbt-package-testing/.github/workflows/run_tox.yml@v2
+        uses: dbt-labs/dbt-package-testing/.github/workflows/run_tox.yml@5d4d8561b9fd193dc0ef2c5a302ad0acc8f68b64
         with:
             # Adapters are read from supported_adapters.env if not specified here
             adapters: "snowflake,bigquery,redshift,databricks"

--- a/.github/workflows/fusion.yml
+++ b/.github/workflows/fusion.yml
@@ -62,7 +62,7 @@ jobs:
 
     fusion-tests:
         needs: run-duckdb-tests
-        uses: dbt-labs/dbt-package-testing/.github/workflows/run_tox_fusion.yml@v2
+        uses: dbt-labs/dbt-package-testing/.github/workflows/run_tox_fusion.yml@5d4d8561b9fd193dc0ef2c5a302ad0acc8f68b64
         with:
             # Only Snowflake for now - add more adapters here as Fusion support expands
             adapters: "snowflake"


### PR DESCRIPTION
## Summary

- The `@v2` tag does not exist in `dbt-labs/dbt-package-testing` (only `v1` through `v1.0.3` are tagged), causing `ci.yml` and `fusion.yml` to fail immediately with a workflow file issue
- Pins both reusable workflow references to commit `5d4d8561` (latest on `main`), which includes `run_tox_fusion.yml` that was added after `v1` was cut

## Test plan

- [ ] Verify `ci.yml` (Package Integration Tests) passes on this PR
- [ ] Verify `fusion.yml` (Fusion Integration Tests) passes on this PR