### PR TITLE
fix: move Fusion DuckDB tests off pull_request_target to safe trigger

### DIFF
--- a/.github/workflows/fusion.yml
+++ b/.github/workflows/fusion.yml
@@ -8,9 +8,6 @@
 # **when?**
 # On every PR, and every push to main and when manually triggered
 
-# **note**
-# DuckDB runs first as a quick check that does not require cloud credentials.
-# Cloud adapter tests use the reusable workflow from dbt-labs/dbt-package-testing.
 
 name: Fusion Integration Tests
 
@@ -28,40 +25,7 @@ env:
     PYTHON_VERSION: "3.11"
 
 jobs:
-    run-duckdb-tests:
-        runs-on: ubuntu-latest
-
-        steps:
-            - name: "Checkout PR code"
-              uses: actions/checkout@v4
-              with:
-                  ref: ${{ github.event.pull_request.head.sha || github.ref }}
-
-            - name: "Set up Python ${{ env.PYTHON_VERSION }}"
-              uses: actions/setup-python@v5
-              with:
-                  python-version: ${{ env.PYTHON_VERSION }}
-
-            - name: "Install dbt Fusion"
-              run: |
-                  curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh
-                  echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-            - name: "Verify Fusion installation"
-              run: |
-                  dbt --version
-
-            - name: "Install tox"
-              run: |
-                  python -m pip install --upgrade pip
-                  pip install tox
-
-            - name: "Run Fusion integration tests on duckdb"
-              run: |
-                  tox -e dbt_integration_fusion_duckdb
-
     fusion-tests:
-        needs: run-duckdb-tests
         uses: dbt-labs/dbt-package-testing/.github/workflows/run_tox_fusion.yml@5d4d8561b9fd193dc0ef2c5a302ad0acc8f68b64
         with:
             # Only Snowflake for now - add more adapters here as Fusion support expands

--- a/.github/workflows/local_only.yml
+++ b/.github/workflows/local_only.yml
@@ -1,5 +1,5 @@
 # **what?**
-# Run tests for packages not supported for cloud testing
+# Run tests for packages not supported for cloud testing, including dbt Fusion + DuckDB
 #
 # **why?**
 # To ensure that packages works as expected with all supported adapters
@@ -81,3 +81,31 @@ jobs:
                 POSTGRES_DATABASE: ${{ env.POSTGRES_DATABASE }}
                 POSTGRES_SCHEMA: "integration_tests_postgres_${{ github.run_number }}"
                 # duckdb - needs no vars
+
+    run-fusion-duckdb-tests:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: "Checkout ${{ github.event.repository }}"
+              uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4
+
+            - name: "Set up Python ${{ env.PYTHON_VERSION }}"
+              uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # actions/setup-python@v5
+              with:
+                  python-version: ${{ env.PYTHON_VERSION }}
+
+            - name: "Install dbt Fusion"
+              run: |
+                  curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh
+                  echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+            - name: "Verify Fusion installation"
+              run: dbt --version
+
+            - name: "Install tox"
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install tox
+
+            - name: "Run Fusion integration tests on duckdb"
+              run: tox -e dbt_integration_fusion_duckdb

--- a/tox.ini
+++ b/tox.ini
@@ -88,7 +88,7 @@ commands =
     bash ./run_tox_tests.sh databricks
 
 # Fusion integration tests - uses --static-analysis=off flag
-# See .github/workflows/fusion.yml for the workflow that installs Fusion
+# See .github/workflows/local_only.yml for the workflow that installs Fusion for DuckDB
 [testenv:dbt_integration_fusion_duckdb]
 allowlist_externals =
     bash


### PR DESCRIPTION
## Summary

- The `run-duckdb-tests` job in `fusion.yml` used `pull_request_target` (runs in base repo context) while checking out and executing fork PR code with no environment approval gate — a classic [pwn-request](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) vulnerability
- Moved the Fusion + DuckDB job into `local_only.yml`, which uses the safe `pull_request` trigger (no base repo context, no secrets)
- Removed `run-duckdb-tests` from `fusion.yml` and dropped the `needs:` dependency from `fusion-tests` (the Snowflake cloud job is already gated by the `cloud-tests` environment for fork PRs)
- Updated the comment in `tox.ini` to point to the new home

## Test plan

- [ ] Verify `Package Integration Tests - Local Only` workflow runs the new `run-fusion-duckdb-tests` job on this PR
- [ ] Verify `Fusion Integration Tests` workflow no longer shows a `run-duckdb-tests` job
- [ ] Verify `fusion-tests` (Snowflake) still requires environment approval for fork PRs