### PR TITLE
fix: use valid type annotation for loop_vars macro argument

### DIFF
--- a/models/staging/variables/variables.yml
+++ b/models/staging/variables/variables.yml
@@ -5,5 +5,5 @@ macros:
     description: A macro that loops through variables and returns them as a SQL query to be used in a model
     arguments:
       - name: vars
-        type: list|string
+        type: any
         description: A list of variables from dbt_project.yml


### PR DESCRIPTION
## Summary

- Changes `type: list|string` to `type: any` in `models/staging/variables/variables.yml` for the `loop_vars` macro's `vars` argument
- dbt-core 1.11 validates macro argument type annotations against a fixed grammar (`str`, `string`, `bool`, `int`, `float`, `any`, `list[...]`, `dict[...]`, `optional[...]`, `relation`, `column`) — union syntax like `list|string` is not valid and triggers a warning on every invocation
- `any` is the correct annotation for an argument that accepts either a list or a string

Fixes #582