### PR TITLE
fix(ci): pin dbt-core<2 for local adapter installs

### DIFF
--- a/.github/workflows/local_only.yml
+++ b/.github/workflows/local_only.yml
@@ -62,7 +62,7 @@ jobs:
             - name: "Install ${{ matrix.adapter }}"
               run: |
                   python -m pip install --upgrade pip
-                  pip install dbt-${{ matrix.adapter }}
+                  pip install "dbt-${{ matrix.adapter }}" "dbt-core<2"
 
             - name: "Install tox"
               run: |


### PR DESCRIPTION
## Summary

- Adds `"dbt-core<2"` to the pip install command in `local_only.yml`

## Root cause

`dbt-postgres 1.10.0` and `dbt-redshift 1.10.1` both declare their `dbt-core` dependency with a pre-release version in the lower bound (`>=1.8.0rc1` and `>=1.8.0b3` respectively) and no upper bound. pip's resolver treats any package whose constraint mentions a pre-release version as eligible for pre-release resolution — so `pip install dbt-postgres` (no `--pre` flag needed) silently resolves to `dbt-core 2.0.0a1` (Fusion).

Fusion rejects postgres as an unsupported adapter, causing the `run-tests (postgres)` job to fail immediately with `InvalidConfig (dbt1005)`.

Other adapters in this workflow are unaffected: `dbt-duckdb` uses a stable lower bound (`>=1.8.0`) so pip won't consider pre-releases, and the constraint is harmless to add there anyway.

## Fix

Adding `"dbt-core<2"` to the install command forces classic dbt-core 1.x for all adapters tested in this workflow.