### PR TITLE
fix: use valid type annotation for loop_vars and enable validate_macro_args

### DIFF
--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -33,6 +33,7 @@ flags:
   require_yaml_configuration_for_mf_time_spines: True
   require_generic_test_arguments_property: True
   require_ref_prefers_node_package_to_root: True
+  validate_macro_args: True
 
 models:
   dbt_project_evaluator_integration_tests:

--- a/integration_tests_2/dbt_project.yml
+++ b/integration_tests_2/dbt_project.yml
@@ -34,6 +34,7 @@ flags:
   require_nested_cumulative_type_params: True
   require_yaml_configuration_for_mf_time_spines: True
   require_generic_test_arguments_property: True
+  validate_macro_args: True
 
 models:
   dbt_project_evaluator_integration_tests_2:

--- a/models/staging/variables/variables.yml
+++ b/models/staging/variables/variables.yml
@@ -5,5 +5,5 @@ macros:
     description: A macro that loops through variables and returns them as a SQL query to be used in a model
     arguments:
       - name: vars
-        type: list|string
-        description: A list of variables from dbt_project.yml
+        type: list[string]
+        description: A list of variable names from dbt_project.yml


### PR DESCRIPTION
## Summary

- Changes `type: list|string` → `type: list[string]` in `models/staging/variables/variables.yml`
- Adds `validate_macro_args: true` to both integration test projects so future invalid annotations are caught in CI

## Root cause

dbt-core 1.11 validates macro argument `type` annotations against a fixed grammar. Union syntax like `list|string` is not valid, so every `dbt parse`/`compile`/`run` against a project installing this package emits a warning. The annotation should be `list[string]`: the argument is always a list of variable *names* (callers build it via `[].append(...)` and the macro iterates it with `for var_name in vars`) — the old union described the dbt var *values* looked up inside the macro, not the argument itself.

## Credit

This builds on the community contribution from @ota2000 in #583. Rebased on main and extended with the `validate_macro_args` flag in integration tests.

Closes #582
Co-authored-by: arakaki <ota2000@users.noreply.github.com>