### PR TITLE
fix: escape single quotes in metric type_params.expr before INSERT

### DIFF
--- a/integration_tests_sl/models/marts/intermediate/_dim_model_7.yml
+++ b/integration_tests_sl/models/marts/intermediate/_dim_model_7.yml
@@ -47,3 +47,9 @@ models:
           {{ Dimension('dim__id') }} > 0
         window: 30 days
         input_metric: total_count
+      - name: metric_with_expr_single_quote
+        label: "Metric with single quote in expr"
+        description: "Regression test: expr containing single quotes must be escaped before INSERT"
+        type: simple
+        agg: count
+        expr: "case when id = 'active' then 1 else 0 end"

--- a/macros/unpack/get_metric_values.sql
+++ b/macros/unpack/get_metric_values.sql
@@ -25,7 +25,7 @@
             wrap_string_with_quotes(node.type_params.measure.alias if node.type_params.measure else none),
             wrap_string_with_quotes(node.type_params.numerator | tojson),
             wrap_string_with_quotes(node.type_params.denominator | tojson),
-            wrap_string_with_quotes(node.type_params.expr),
+            wrap_string_with_quotes(dbt.escape_single_quotes(node.type_params.expr)),
             wrap_string_with_quotes(((node.type_params.cumulative_type_params.window if node.type_params.cumulative_type_params else none) or node.type_params.window) | tojson),
             wrap_string_with_quotes((node.type_params.cumulative_type_params.grain_to_date or node.type_params.grain_to_date) if node.type_params.cumulative_type_params else node.type_params.grain_to_date),
             wrap_string_with_quotes(node.meta | tojson)


### PR DESCRIPTION
## Summary

- `get_metric_values()` passed `node.type_params.expr` directly to `wrap_string_with_quotes()`, which calls `dbt.string_literal()` and wraps the value in single quotes
- When `type_params.expr` contains a single quote (e.g. a CASE expression like `case when id = 'active' then 1 else 0 end` from a measure converted by dbt Wizard), the generated INSERT SQL is syntactically invalid
- Fix: wrap with `dbt.escape_single_quotes()` before passing to `wrap_string_with_quotes()`, matching the treatment already applied to `label` and `filter`

## Regression test

Added `metric_with_expr_single_quote` to `integration_tests_sl` with `expr: "case when id = 'active' then 1 else 0 end"`. Without the fix this produces:

```
Parser Error: syntax error at or near "active"
LINE 58: 'case when id = 'active' then 1 else 0 end'
```

## Related

Reported via ZD-125778 (Frog Street)