### PR TITLE
fix: is_freshness_enabled ignores error_after when warn_after is unset

### DIFF
--- a/integration_tests/models/staging/source_1/source.yml
+++ b/integration_tests/models/staging/source_1/source.yml
@@ -27,6 +27,9 @@ sources:
     # database: real_database
     tables:
       - name: table_3
+        config:
+          freshness: # regression test for issue #520: error_after only, no warn_after
+            error_after: {count: 24, period: hour}
 
   - name: source_3
     schema: real_schema_3

--- a/integration_tests/seeds/tests/test_fct_sources_without_freshness.csv
+++ b/integration_tests/seeds/tests/test_fct_sources_without_freshness.csv
@@ -1,3 +1,2 @@
-﻿resource_name
-source_2.table_3
+resource_name
 source_1.table_5

--- a/macros/unpack/get_source_values.sql
+++ b/macros/unpack/get_source_values.sql
@@ -26,10 +26,10 @@
               wrap_string_with_quotes(node.loaded_at_field | replace("'", "_")),
 
               "cast(" ~ dbt_project_evaluator.bool_literal(
-                ((node.config.freshness != None) and (dbt_project_evaluator.is_not_empty_string(node.config.freshness.warn_after.count)
-                  or dbt_project_evaluator.is_not_empty_string(node.config.freshness.error_after.count)))
-                or ((node.freshness != None) and (dbt_project_evaluator.is_not_empty_string(node.freshness.warn_after.count)
-                  or dbt_project_evaluator.is_not_empty_string(node.freshness.error_after.count)))
+                ((node.config.freshness != None) and (node.config.freshness.warn_after.count is not none
+                  or node.config.freshness.error_after.count is not none))
+                or ((node.freshness != None) and (node.freshness.warn_after.count is not none
+                  or node.freshness.error_after.count is not none))
                 ) | trim ~ " as " ~ dbt.type_boolean() ~ ")",
 
               wrap_string_with_quotes(node.database),


### PR DESCRIPTION
## Summary
- Fixes #520: sources configured with only `error_after` (no `warn_after`) were incorrectly flagged with `is_freshness_enabled = false`.
- Root cause: `macros/unpack/get_source_values.sql` called `dbt_project_evaluator.is_not_empty_string(...)` inside a Jinja `and`/`or` expression. A Jinja macro call always returns its rendered text, which is a non-empty (truthy) string regardless of the actual boolean it represents. This made the `or` between the `warn_after` and `error_after` checks always short-circuit on the `warn_after` check, so `error_after` was never actually evaluated.
- Fix: replace the macro calls with direct `is not none` checks on `warn_after.count` / `error_after.count`, which evaluate to real Python booleans.

## Test plan
- Added a regression fixture in `integration_tests`: `source_2.table_3` now has a freshness config with only `error_after` set.
- Updated `test_fct_sources_without_freshness.csv` to reflect the correct expected output (table_3 should no longer be flagged).
- Verified TDD red/green: the `equality_fct_sources_without_freshness` test fails against the unfixed macro and passes after the fix.
- Ran the full local integration suite (duckdb target) to confirm no other tests regressed.