### PR TITLE
fix: correct +enabled Jinja precedence bug in ci-check docs

### DIFF
--- a/docs/ci-check.md
+++ b/docs/ci-check.md
@@ -26,7 +26,7 @@ By default the tests in this package are configured with "warn" severity, we can
         ```yaml title="dbt_project.yml"
         models:
           dbt_project_evaluator:
-            +enabled: "{{ env_var('DBT_PROJECT_EVALUATOR_ENABLED', 'true') | lower == 'true' | as_bool }}"
+            +enabled: "{{ (env_var('DBT_PROJECT_EVALUATOR_ENABLED', 'true') | lower == 'true') | as_bool }}"
         ```
 
 ## 2. Run this package for each pull request


### PR DESCRIPTION
## Summary

Fixes #589.

The `+enabled` example in the "disable the package for production" note in [`docs/ci-check.md`](docs/ci-check.md) has an operator-precedence bug:

```yaml
+enabled: "{{ env_var('DBT_PROJECT_EVALUATOR_ENABLED', 'true') | lower == 'true' | as_bool }}"
```

Jinja filters bind tighter than `==`, so this parses as `lower(env_var(...)) == as_bool('true')` — `as_bool` silently attaches to the string literal `'true'` instead of to the comparison result.

Under dbt-fusion, this always evaluates falsy, disabling every model in the package regardless of what the env var is actually set to (only the `dbt_project_evaluator_exceptions` seed still runs, since seeds aren't affected by this `models:` config block). It happens to still "work" under dbt-core only because of an internal, undocumented implementation detail: dbt-core's native config renderer implements `as_bool` as `BoolMarker`, a `str` subclass used as a deferred marker rather than an immediate boolean conversion, so the (still-string) comparison accidentally lands on the right answer.

## Fix

Wrap the comparison in parentheses before piping to `as_bool`:

```yaml
+enabled: "{{ (env_var('DBT_PROJECT_EVALUATOR_ENABLED', 'true') | lower == 'true') | as_bool }}"
```

This matches the pattern used in dbt-fusion's own conformance test fixtures (`test_disabled_configs/test_conditional_model`) and works correctly on both dbt-core and dbt-fusion.

## Test plan

Reproduced with a minimal DuckDB project on both engines, setting `+enabled` to the exact doc expression:

| Engine | env var `true` | env var `false` |
|---|---|---|
| dbt-fusion 2.0.0-preview.202 (before fix) | 0 models built | 0 models built |
| dbt-fusion 2.0.0-preview.202 (after fix) | all models built | 0 models built |
| dbt-core 1.12.0 (before and after fix) | all models built | 0 models built |

- [x] Confirmed the broken expression always disables models on Fusion regardless of env var value
- [x] Confirmed the parenthesized fix enables/disables correctly on Fusion based on the env var
- [x] Confirmed the fix doesn't regress dbt-core behavior
- [x] Docs-only change, no models/macros affected — no integration test changes needed