### PR TITLE
feat: add native parse-time project checks

### DIFF
--- a/checks/README.md
+++ b/checks/README.md
@@ -1,0 +1,36 @@
+# Native project checks
+
+These checks reproduce 28 of the 29 dbt-project-evaluator rules using
+parse-time dbt information-schema metadata. Each SQL file follows the native
+checks contract: zero rows pass; returned rows are violations.
+They default to `severity: warn`, matching the package's advisory behavior and
+allowing ordinary `dbt build` invocations to continue after reporting findings.
+
+## Implemented
+
+- DAG: duplicate/unused sources, source/model fanout, multiple sources joined,
+  direct joins to sources, root models, too many direct parents, rejoining
+  upstream concepts, and layer-direction checks.
+- Documentation and tests: undocumented models, source tables, and sources;
+  aggregate documentation and test coverage; source freshness; primary-key
+  test coverage; and test-directory parity.
+- Governance: exposure parents must be public models, public models require
+  contracts, and public model/column documentation coverage.
+- Structure and performance: source/model directory placement, model naming
+  conventions, chained views, and exposure parent materializations.
+
+The existing evaluator variables remain the configuration surface for
+thresholds and conventions, including `models_fanout_threshold`,
+`too_many_joins_threshold`, `chained_views_threshold`,
+`documentation_coverage_target`, `test_coverage_target`,
+`primary_key_test_macros`, model folders, and model prefixes.
+
+## Deferred
+
+- `fct_hard_coded_references` requires parsed SQL or lint/static-analysis
+  findings. It is intentionally not approximated with raw string matching at
+  parse time.
+
+Package and path exclusions are supported. Row-level exceptions from the
+`dbt_project_evaluator_exceptions` seed remain future work because native
+parse-time checks do not execute or depend on warehouse seed relations.

--- a/checks/fct_chained_views_dependencies.sql
+++ b/checks/fct_chained_views_dependencies.sql
@@ -1,0 +1,48 @@
+with recursive scoped_nodes as (
+    select *
+    from {{ info_schema('graph_nodes') }} node
+    where {{ evaluator_check_in_scope('node') }}
+),
+direct_edges as (
+    select edge.parent_unique_id, edge.child_unique_id
+    from {{ info_schema('edges') }} edge
+    join scoped_nodes parent on parent.unique_id = edge.parent_unique_id
+    join scoped_nodes child on child.unique_id = edge.child_unique_id
+),
+chains(origin, current_node, distance, path, chain_of_views) as (
+    select edge.parent_unique_id,
+           edge.child_unique_id,
+           1,
+           [edge.parent_unique_id, edge.child_unique_id],
+           coalesce(parent.materialized, '') in ('view', 'ephemeral')
+    from direct_edges edge
+    join scoped_nodes parent on parent.unique_id = edge.parent_unique_id
+
+    union all
+
+    select chains.origin,
+           edge.child_unique_id,
+           chains.distance + 1,
+           list_append(chains.path, edge.child_unique_id),
+           chains.chain_of_views
+             and coalesce(current_node.materialized, '') in ('view', 'ephemeral')
+    from chains
+    join scoped_nodes current_node
+      on current_node.unique_id = chains.current_node
+    join direct_edges edge
+      on edge.parent_unique_id = chains.current_node
+    where not list_contains(chains.path, edge.child_unique_id)
+),
+violations as (
+    select parent.name as parent,
+           child.name as child,
+           chains.distance,
+           chains.path
+    from chains
+    join scoped_nodes parent on parent.unique_id = chains.origin
+    join scoped_nodes child on child.unique_id = chains.current_node
+    where chains.chain_of_views
+      and child.resource_type = 'model'
+      and chains.distance > {{ var('chained_views_threshold', 5) }}
+)
+select * from violations

--- a/checks/fct_direct_join_to_source.sql
+++ b/checks/fct_direct_join_to_source.sql
@@ -1,0 +1,12 @@
+with parent_types as (
+    select e.child_unique_id as unique_id,
+           count(*) filter (where s.unique_id is not null) as source_parents,
+           count(*) filter (where p.unique_id is not null) as model_parents
+    from {{ info_schema('edges') }} e
+    join {{ info_schema('models') }} child on child.unique_id = e.child_unique_id
+    left join {{ info_schema('sources') }} s on s.unique_id = e.parent_unique_id
+    left join {{ info_schema('models') }} p on p.unique_id = e.parent_unique_id
+    where {{ evaluator_check_in_scope('child') }}
+    group by e.child_unique_id
+)
+select * from parent_types where source_parents > 0 and model_parents > 0

--- a/checks/fct_documentation_coverage.sql
+++ b/checks/fct_documentation_coverage.sql
@@ -1,0 +1,65 @@
+with typed_models as (
+    select m.*,
+           case
+               when regexp_matches(m.name, '^base_') then 'base'
+               when regexp_matches(m.name, '^stg_') then 'staging'
+               when regexp_matches(m.name, '^int_') then 'intermediate'
+               when regexp_matches(m.name, '^(fct|dim)_') then 'marts'
+               when m.original_file_path like '%/base/%' then 'base'
+               when m.original_file_path like '%/staging/%' then 'staging'
+               when m.original_file_path like '%/intermediate/%' then 'intermediate'
+               when m.original_file_path like '%/marts/%' then 'marts'
+               else 'other'
+           end as model_type
+    from {{ info_schema('models') }} m
+    where {{ evaluator_check_in_scope('m') }}
+),
+coverage as (
+    select count(*) as total_models,
+           count(*) filter (
+               where nullif(trim(description), '') is not null
+           ) as documented_models,
+           round(
+               count(*) filter (
+                   where nullif(trim(description), '') is not null
+                     and model_type = 'staging'
+               ) * 100.0
+               / nullif(count(*) filter (where model_type = 'staging'), 0),
+               2
+           ) as staging_documentation_coverage_pct,
+           round(
+               count(*) filter (
+                   where nullif(trim(description), '') is not null
+                     and model_type = 'intermediate'
+               ) * 100.0
+               / nullif(count(*) filter (where model_type = 'intermediate'), 0),
+               2
+           ) as intermediate_documentation_coverage_pct,
+           round(
+               count(*) filter (
+                   where nullif(trim(description), '') is not null
+                     and model_type = 'marts'
+               ) * 100.0
+               / nullif(count(*) filter (where model_type = 'marts'), 0),
+               2
+           ) as marts_documentation_coverage_pct,
+           round(
+               count(*) filter (
+                   where nullif(trim(description), '') is not null
+                     and model_type = 'other'
+               ) * 100.0
+               / nullif(count(*) filter (where model_type = 'other'), 0),
+               2
+           ) as other_documentation_coverage_pct
+    from typed_models
+)
+select total_models, documented_models,
+       round(documented_models * 100.0 / nullif(total_models, 0), 2)
+       as documentation_coverage_pct,
+       staging_documentation_coverage_pct,
+       intermediate_documentation_coverage_pct,
+       marts_documentation_coverage_pct,
+       other_documentation_coverage_pct
+from coverage
+where documented_models * 100.0 / nullif(total_models, 0)
+      < {{ var('documentation_coverage_target', 100) }}

--- a/checks/fct_duplicate_sources.sql
+++ b/checks/fct_duplicate_sources.sql
@@ -1,0 +1,15 @@
+with sources as (
+    select database_name, schema_name, identifier,
+           source_name || '.' || name as resource_name
+    from {{ info_schema('sources') }} s
+    where {{ evaluator_check_in_scope('s') }}
+),
+duplicates as (
+    select database_name, schema_name, identifier,
+           list(resource_name order by resource_name) as source_names,
+           count(*) as source_count
+    from sources
+    group by database_name, schema_name, identifier
+    having count(*) > 1
+)
+select * from duplicates

--- a/checks/fct_exposure_parents_materializations.sql
+++ b/checks/fct_exposure_parents_materializations.sql
@@ -1,0 +1,24 @@
+select parent.resource_type as parent_resource_type,
+       case
+           when parent.resource_type = 'source'
+           then parent.source_name || '.' || parent.name
+           else parent.name
+       end as parent_resource_name,
+       exposure.name as exposure_name,
+       model.materialized as parent_model_materialization
+from {{ info_schema('exposures') }} exposure
+join {{ info_schema('edges') }} edge
+  on edge.child_unique_id = exposure.unique_id
+join {{ info_schema('graph_nodes') }} parent
+  on parent.unique_id = edge.parent_unique_id
+left join {{ info_schema('models') }} model
+  on model.unique_id = parent.unique_id
+where {{ evaluator_check_in_scope('exposure') }}
+  and {{ evaluator_check_in_scope('parent') }}
+  and (
+      parent.resource_type = 'source'
+      or (
+          parent.resource_type = 'model'
+          and model.materialized in ('view', 'ephemeral')
+      )
+  )

--- a/checks/fct_exposures_dependent_on_private_models.sql
+++ b/checks/fct_exposures_dependent_on_private_models.sql
@@ -1,0 +1,19 @@
+select exposure.unique_id as exposure_unique_id,
+       exposure.name as exposure_name,
+       parent.unique_id as parent_unique_id,
+       parent.name as parent_resource_name,
+       model.access as parent_access,
+       parent.resource_type as parent_resource_type
+from {{ info_schema('exposures') }} exposure
+join {{ info_schema('edges') }} edge
+  on edge.child_unique_id = exposure.unique_id
+join {{ info_schema('graph_nodes') }} parent
+  on parent.unique_id = edge.parent_unique_id
+left join {{ info_schema('models') }} model
+  on model.unique_id = parent.unique_id
+where {{ evaluator_check_in_scope('exposure') }}
+  and {{ evaluator_check_in_scope('parent') }}
+  and not (
+      parent.resource_type = 'model'
+      and model.access = 'public'
+  )

--- a/checks/fct_marts_or_intermediate_dependent_on_source.sql
+++ b/checks/fct_marts_or_intermediate_dependent_on_source.sql
@@ -1,0 +1,21 @@
+with typed as (
+    select m.unique_id, case
+            when regexp_matches(m.name, '^base_') then 'base'
+            when regexp_matches(m.name, '^stg_') then 'staging'
+            when regexp_matches(m.name, '^int_') then 'intermediate'
+            when regexp_matches(m.name, '^(fct|dim)_') then 'marts'
+            when m.original_file_path like '%/base/%' then 'base'
+            when m.original_file_path like '%/staging/%' then 'staging'
+            when m.original_file_path like '%/intermediate/%' then 'intermediate'
+            when m.original_file_path like '%/marts/%' then 'marts'
+            else 'other'
+        end as model_type
+    from {{ info_schema('models') }} m
+    where {{ evaluator_check_in_scope('m') }}
+)
+select child.unique_id, e.parent_unique_id, child.model_type
+from {{ info_schema('edges') }} e
+join {{ info_schema('sources') }} source on source.unique_id = e.parent_unique_id
+join typed child on child.unique_id = e.child_unique_id
+where {{ evaluator_check_in_scope('source') }}
+  and child.model_type in ('marts', 'intermediate')

--- a/checks/fct_missing_primary_key_tests.sql
+++ b/checks/fct_missing_primary_key_tests.sql
@@ -1,0 +1,86 @@
+with resources as (
+    select unique_id, name, resource_type, package_name,
+           original_file_path, primary_key
+    from {{ info_schema('models') }}
+    union all by name
+    select unique_id, name, resource_type, package_name,
+           original_file_path, primary_key
+    from {{ info_schema('seeds') }}
+    union all by name
+    select unique_id, name, resource_type, package_name,
+           original_file_path, primary_key
+    from {{ info_schema('snapshots') }}
+    union all by name
+    select unique_id, source_name || '.' || name as name, resource_type,
+           package_name, original_file_path, primary_key
+    from {{ info_schema('sources') }}
+),
+tests as (
+    select node_unique_id, column_name,
+           coalesce(test_definition_package, 'dbt')
+           || '.test_' || test_name as full_test_name
+    from {{ info_schema('data_tests') }}
+    where node_unique_id is not null
+      and test_name is not null
+),
+column_constraints as (
+    select node_unique_id, column_name,
+           coalesce(constraints, '') like '%not_null%' as has_not_null_constraint,
+           case
+               when constraints is null or constraints = '' then 0
+               else coalesce(json_array_length(constraints), 0)
+           end as constraint_count
+    from {{ info_schema('node_columns') }}
+),
+qualified_columns as (
+    select tests.node_unique_id, tests.column_name
+    from tests
+    left join column_constraints
+      on column_constraints.node_unique_id = tests.node_unique_id
+     and column_constraints.column_name = tests.column_name
+    group by tests.node_unique_id, tests.column_name
+    having
+        {% for test_set in var('primary_key_test_macros', [['dbt.test_unique', 'dbt.test_not_null'], ['dbt_utils.test_unique_combination_of_columns']]) %}
+        count(distinct case
+            when full_test_name in (
+                {% for test_name in test_set %}
+                '{{ test_name }}'{% if not loop.last %}, {% endif %}
+                {% endfor %}
+            )
+            then full_test_name
+        end) >= {{ test_set | length }}
+        {% if not loop.last %}or{% endif %}
+        {% endfor %}
+        or (
+            bool_or(full_test_name = 'dbt.test_unique')
+            and bool_or(coalesce(has_not_null_constraint, false))
+        )
+),
+qualified_nodes as (
+    select distinct node_unique_id from qualified_columns
+),
+test_counts as (
+    select node_unique_id, count(*) as number_of_tests_on_model
+    from tests
+    group by node_unique_id
+),
+constraint_counts as (
+    select node_unique_id, sum(constraint_count) as number_of_constraints_on_model
+    from column_constraints
+    group by node_unique_id
+)
+select r.unique_id, r.name, r.resource_type,
+       false as is_primary_key_tested,
+       coalesce(t.number_of_tests_on_model, 0) as number_of_tests_on_model,
+       coalesce(c.number_of_constraints_on_model, 0) as number_of_constraints_on_model
+from resources r
+left join qualified_nodes q on q.node_unique_id = r.unique_id
+left join test_counts t on t.node_unique_id = r.unique_id
+left join constraint_counts c on c.node_unique_id = r.unique_id
+where {{ evaluator_check_in_scope('r') }}
+  and r.resource_type in (
+      {% for resource_type in var('enforced_primary_key_node_types', ['model']) %}
+      '{{ resource_type }}'{% if not loop.last %}, {% endif %}
+      {% endfor %}
+  )
+  and q.node_unique_id is null

--- a/checks/fct_model_directories.sql
+++ b/checks/fct_model_directories.sql
@@ -1,0 +1,100 @@
+with recursive models as (
+    select m.*,
+           replace(m.original_file_path, chr(92), '/') as normalized_path
+    from {{ info_schema('models') }} m
+    where {{ evaluator_check_in_scope('m') }}
+      and not exists (
+          select 1 from {{ info_schema('time_spines') }} ts
+          where ts.unique_id = m.unique_id
+      )
+),
+typed as (
+    select *,
+           case
+               {% for model_type in var('model_types', ['base', 'staging', 'intermediate', 'marts', 'other']) %}
+               {% set prefixes = var(model_type ~ '_prefixes', []) %}
+               {% if prefixes is string %}{% set prefixes = [prefixes] %}{% endif %}
+               {% for prefix in prefixes %}
+               when starts_with(name, '{{ prefix }}') then '{{ model_type }}'
+               {% endfor %}
+               {% endfor %}
+               {% for model_type in var('model_types', ['base', 'staging', 'intermediate', 'marts', 'other']) if model_type != 'other' %}
+               when regexp_matches(
+                   normalized_path,
+                   '(^|/){{ var(model_type ~ "_folder_name", model_type) }}(/|$)'
+               ) then '{{ model_type }}'
+               {% endfor %}
+               else 'other'
+           end as model_type
+    from models
+),
+foldered as (
+    select *,
+           case
+               {% for model_type in var('model_types', ['base', 'staging', 'intermediate', 'marts', 'other']) if model_type != 'other' %}
+               when regexp_matches(
+                   normalized_path,
+                   '(^|/){{ var(model_type ~ "_folder_name", model_type) }}(/|$)'
+               ) then '{{ model_type }}'
+               {% endfor %}
+               else 'other'
+           end as folder_model_type,
+           regexp_extract(normalized_path, '^(.*)/[^/]+$', 1) as directory_path
+    from typed
+),
+source_paths(source_unique_id, child_unique_id, path) as (
+    select source.unique_id,
+           edge.child_unique_id,
+           [source.unique_id, edge.child_unique_id]
+    from {{ info_schema('sources') }} source
+    join {{ info_schema('edges') }} edge
+      on edge.parent_unique_id = source.unique_id
+    where {{ evaluator_check_in_scope('source') }}
+
+    union all
+
+    select source_paths.source_unique_id,
+           edge.child_unique_id,
+           list_append(source_paths.path, edge.child_unique_id)
+    from source_paths
+    join {{ info_schema('edges') }} edge
+      on edge.parent_unique_id = source_paths.child_unique_id
+    where not list_contains(source_paths.path, edge.child_unique_id)
+),
+staging_source_violations as (
+    select distinct
+           child.unique_id,
+           child.name,
+           child.model_type,
+           child.original_file_path as current_file_path,
+           'models/{{ var("staging_folder_name", "staging") }}/'
+           || source.source_name || '/'
+           || regexp_extract(child.normalized_path, '[^/]+$', 0)
+           as change_file_path_to
+    from foldered child
+    join source_paths path on path.child_unique_id = child.unique_id
+    join {{ info_schema('sources') }} source
+      on source.unique_id = path.source_unique_id
+    where child.model_type = 'staging'
+      and child.directory_path not like '%' || source.source_name || '%'
+),
+folder_violations as (
+    select unique_id, name, model_type,
+           original_file_path as current_file_path,
+           'models/.../'
+           || case model_type
+               {% for model_type in var('model_types', ['base', 'staging', 'intermediate', 'marts', 'other']) if model_type != 'other' %}
+               when '{{ model_type }}' then '{{ var(model_type ~ "_folder_name", model_type) }}'
+               {% endfor %}
+               else model_type
+              end
+           || '/.../'
+           || regexp_extract(normalized_path, '[^/]+$', 0)
+           as change_file_path_to
+    from foldered
+    where model_type != 'other'
+      and model_type != folder_model_type
+)
+select * from staging_source_violations
+union all by name
+select * from folder_violations

--- a/checks/fct_model_fanout.sql
+++ b/checks/fct_model_fanout.sql
@@ -1,0 +1,17 @@
+with leaf_models as (
+    select m.unique_id
+    from {{ info_schema('models') }} m
+    left join {{ info_schema('edges') }} outgoing on outgoing.parent_unique_id = m.unique_id
+    where {{ evaluator_check_in_scope('m') }}
+    group by m.unique_id
+    having count(outgoing.child_unique_id) = 0
+),
+fanout as (
+    select e.parent_unique_id as unique_id,
+           count(distinct e.child_unique_id) as leaf_children
+    from {{ info_schema('edges') }} e
+    join leaf_models leaf on leaf.unique_id = e.child_unique_id
+    group by e.parent_unique_id
+)
+select * from fanout
+where leaf_children >= {{ var('models_fanout_threshold', 3) }}

--- a/checks/fct_model_naming_conventions.sql
+++ b/checks/fct_model_naming_conventions.sql
@@ -1,0 +1,29 @@
+with typed as (
+    select m.unique_id, m.name, m.original_file_path,
+           case
+            when regexp_matches(m.name, '^base_') then 'base'
+            when regexp_matches(m.name, '^stg_') then 'staging'
+            when regexp_matches(m.name, '^int_') then 'intermediate'
+            when regexp_matches(m.name, '^(fct|dim)_') then 'marts'
+            when m.original_file_path like '%/base/%' then 'base'
+            when m.original_file_path like '%/staging/%' then 'staging'
+            when m.original_file_path like '%/intermediate/%' then 'intermediate'
+            when m.original_file_path like '%/marts/%' then 'marts'
+            else 'other'
+        end as model_type
+    from {{ info_schema('models') }} m
+    where {{ evaluator_check_in_scope('m') }}
+      and not exists (
+      select 1 from {{ info_schema('time_spines') }} ts
+      where ts.unique_id = m.unique_id
+  )
+)
+select unique_id, name, model_type, original_file_path
+from typed
+where (model_type = 'base' and not regexp_matches(name, '^base_'))
+   or (model_type = 'staging' and not regexp_matches(name, '^stg_'))
+   or (model_type = 'intermediate' and not regexp_matches(name, '^int_'))
+   or (model_type = 'marts'
+       and not regexp_matches(name, '^fct_')
+       and not regexp_matches(name, '^dim_'))
+   or (model_type = 'other' and not regexp_matches(name, '^rpt_'))

--- a/checks/fct_multiple_sources_joined.sql
+++ b/checks/fct_multiple_sources_joined.sql
@@ -1,0 +1,11 @@
+with source_parents as (
+    select e.child_unique_id as unique_id,
+           count(distinct e.parent_unique_id) as source_parents
+    from {{ info_schema('edges') }} e
+    join {{ info_schema('sources') }} s on s.unique_id = e.parent_unique_id
+    join {{ info_schema('models') }} m on m.unique_id = e.child_unique_id
+    where {{ evaluator_check_in_scope('s') }}
+      and {{ evaluator_check_in_scope('m') }}
+    group by e.child_unique_id
+)
+select * from source_parents where source_parents > 1

--- a/checks/fct_public_models_without_contract.sql
+++ b/checks/fct_public_models_without_contract.sql
@@ -1,0 +1,5 @@
+select unique_id, name, access, contract_enforced
+from {{ info_schema('models') }} m
+where {{ evaluator_check_in_scope('m') }}
+  and access = 'public'
+  and not coalesce(contract_enforced, false)

--- a/checks/fct_rejoining_of_upstream_concepts.sql
+++ b/checks/fct_rejoining_of_upstream_concepts.sql
@@ -1,0 +1,66 @@
+with recursive scoped_nodes as (
+    select *
+    from {{ info_schema('graph_nodes') }} node
+    where {{ evaluator_check_in_scope('node') }}
+      and resource_type not in ('exposure', 'metric')
+),
+direct_edges as (
+    select edge.parent_unique_id, edge.child_unique_id
+    from {{ info_schema('edges') }} edge
+    join scoped_nodes parent on parent.unique_id = edge.parent_unique_id
+    join scoped_nodes child on child.unique_id = edge.child_unique_id
+),
+paths(parent_unique_id, child_unique_id, distance, path) as (
+    select parent_unique_id, child_unique_id, 1,
+           [parent_unique_id, child_unique_id]
+    from direct_edges
+
+    union all
+
+    select paths.parent_unique_id,
+           edge.child_unique_id,
+           paths.distance + 1,
+           list_append(paths.path, edge.child_unique_id)
+    from paths
+    join direct_edges edge
+      on edge.parent_unique_id = paths.child_unique_id
+    where not list_contains(paths.path, edge.child_unique_id)
+),
+rejoined as (
+    select parent_unique_id, child_unique_id
+    from paths
+    group by parent_unique_id, child_unique_id
+    having count(*) filter (where distance = 1) > 0
+       and count(*) filter (where distance = 2) > 0
+),
+single_use as (
+    select parent_unique_id
+    from direct_edges
+    group by parent_unique_id
+    having count(*) = 1
+),
+triads as (
+    select distinct rejoined.parent_unique_id,
+           rejoined.child_unique_id,
+           first_hop.child_unique_id as parent_and_child_unique_id
+    from rejoined
+    join direct_edges first_hop
+      on first_hop.parent_unique_id = rejoined.parent_unique_id
+    join direct_edges second_hop
+      on second_hop.parent_unique_id = first_hop.child_unique_id
+     and second_hop.child_unique_id = rejoined.child_unique_id
+    join single_use
+      on single_use.parent_unique_id = first_hop.child_unique_id
+)
+select parent.name as parent,
+       case
+           when child.version is null then child.name
+           else child.name || '.v' || cast(child.version as varchar)
+       end as child,
+       parent_and_child.name as parent_and_child,
+       true as is_loop_independent
+from triads
+join scoped_nodes parent on parent.unique_id = triads.parent_unique_id
+join scoped_nodes child on child.unique_id = triads.child_unique_id
+join scoped_nodes parent_and_child
+  on parent_and_child.unique_id = triads.parent_and_child_unique_id

--- a/checks/fct_root_models.sql
+++ b/checks/fct_root_models.sql
@@ -1,0 +1,10 @@
+select m.unique_id, m.name, m.original_file_path
+from {{ info_schema('models') }} m
+left join {{ info_schema('edges') }} e on e.child_unique_id = m.unique_id
+where {{ evaluator_check_in_scope('m') }}
+  and not exists (
+      select 1 from {{ info_schema('time_spines') }} ts
+      where ts.unique_id = m.unique_id
+  )
+group by m.unique_id, m.name, m.original_file_path
+having count(e.parent_unique_id) = 0

--- a/checks/fct_source_directories.sql
+++ b/checks/fct_source_directories.sql
@@ -1,0 +1,17 @@
+with sources as (
+    select unique_id, source_name, original_file_path,
+           regexp_extract(
+               replace(original_file_path, chr(92), '/'),
+               '^(.*)/[^/]+$',
+               1
+           ) as directory_path
+    from {{ info_schema('sources') }} s
+    where {{ evaluator_check_in_scope('s') }}
+)
+select unique_id, source_name, original_file_path as current_file_path,
+       'models/{{ var("staging_folder_name", "staging") }}/'
+       || source_name || '/'
+       || regexp_extract(replace(original_file_path, chr(92), '/'), '[^/]+$', 0)
+       as change_file_path_to
+from sources
+where directory_path not like '%' || source_name || '%'

--- a/checks/fct_source_fanout.sql
+++ b/checks/fct_source_fanout.sql
@@ -1,0 +1,11 @@
+with source_children as (
+    select e.parent_unique_id as unique_id,
+           count(distinct e.child_unique_id) as model_children
+    from {{ info_schema('edges') }} e
+    join {{ info_schema('sources') }} s on s.unique_id = e.parent_unique_id
+    join {{ info_schema('models') }} m on m.unique_id = e.child_unique_id
+    where {{ evaluator_check_in_scope('s') }}
+      and {{ evaluator_check_in_scope('m') }}
+    group by e.parent_unique_id
+)
+select * from source_children where model_children > 1

--- a/checks/fct_sources_without_freshness.sql
+++ b/checks/fct_sources_without_freshness.sql
@@ -1,0 +1,10 @@
+select distinct unique_id, source_name, name
+from {{ info_schema('sources') }} s
+where {{ evaluator_check_in_scope('s') }}
+  and (
+      freshness is null
+      or (
+          json_extract_string(freshness, '$.warn_after.count') is null
+          and json_extract_string(freshness, '$.error_after.count') is null
+      )
+  )

--- a/checks/fct_staging_dependent_on_marts_or_intermediate.sql
+++ b/checks/fct_staging_dependent_on_marts_or_intermediate.sql
@@ -1,0 +1,21 @@
+with typed as (
+    select m.unique_id, case
+            when regexp_matches(m.name, '^base_') then 'base'
+            when regexp_matches(m.name, '^stg_') then 'staging'
+            when regexp_matches(m.name, '^int_') then 'intermediate'
+            when regexp_matches(m.name, '^(fct|dim)_') then 'marts'
+            when m.original_file_path like '%/base/%' then 'base'
+            when m.original_file_path like '%/staging/%' then 'staging'
+            when m.original_file_path like '%/intermediate/%' then 'intermediate'
+            when m.original_file_path like '%/marts/%' then 'marts'
+            else 'other'
+        end as model_type
+    from {{ info_schema('models') }} m
+    where {{ evaluator_check_in_scope('m') }}
+)
+select child.unique_id, e.parent_unique_id, parent.model_type as parent_model_type
+from {{ info_schema('edges') }} e
+join typed parent on parent.unique_id = e.parent_unique_id
+join typed child on child.unique_id = e.child_unique_id
+where child.model_type = 'staging'
+  and parent.model_type in ('marts', 'intermediate')

--- a/checks/fct_staging_dependent_on_staging.sql
+++ b/checks/fct_staging_dependent_on_staging.sql
@@ -1,0 +1,20 @@
+with typed as (
+    select m.unique_id, case
+            when regexp_matches(m.name, '^base_') then 'base'
+            when regexp_matches(m.name, '^stg_') then 'staging'
+            when regexp_matches(m.name, '^int_') then 'intermediate'
+            when regexp_matches(m.name, '^(fct|dim)_') then 'marts'
+            when m.original_file_path like '%/base/%' then 'base'
+            when m.original_file_path like '%/staging/%' then 'staging'
+            when m.original_file_path like '%/intermediate/%' then 'intermediate'
+            when m.original_file_path like '%/marts/%' then 'marts'
+            else 'other'
+        end as model_type
+    from {{ info_schema('models') }} m
+    where {{ evaluator_check_in_scope('m') }}
+)
+select child.unique_id, e.parent_unique_id
+from {{ info_schema('edges') }} e
+join typed parent on parent.unique_id = e.parent_unique_id
+join typed child on child.unique_id = e.child_unique_id
+where parent.model_type = 'staging' and child.model_type = 'staging'

--- a/checks/fct_test_coverage.sql
+++ b/checks/fct_test_coverage.sql
@@ -1,0 +1,78 @@
+with scoped_models as (
+    select m.*,
+           case
+               when regexp_matches(m.name, '^base_') then 'base'
+               when regexp_matches(m.name, '^stg_') then 'staging'
+               when regexp_matches(m.name, '^int_') then 'intermediate'
+               when regexp_matches(m.name, '^(fct|dim)_') then 'marts'
+               when m.original_file_path like '%/base/%' then 'base'
+               when m.original_file_path like '%/staging/%' then 'staging'
+               when m.original_file_path like '%/intermediate/%' then 'intermediate'
+               when m.original_file_path like '%/marts/%' then 'marts'
+               else 'other'
+           end as model_type
+    from {{ info_schema('models') }} m
+    where {{ evaluator_check_in_scope('m') }}
+),
+test_attachments as (
+    select distinct t.unique_id as test_unique_id,
+           t.node_unique_id as model_unique_id
+    from {{ info_schema('data_tests') }} t
+    where t.node_unique_id is not null
+
+    union all
+
+    select distinct t.unique_id as test_unique_id,
+           edge.parent_unique_id as model_unique_id
+    from {{ info_schema('data_tests') }} t
+    join {{ info_schema('edges') }} edge
+      on edge.child_unique_id = t.unique_id
+    join scoped_models model
+      on model.unique_id = edge.parent_unique_id
+    where t.node_unique_id is null
+),
+model_tests as (
+    select model.unique_id,
+           model.model_type,
+           count(distinct attachment.test_unique_id) as test_count
+    from scoped_models model
+    left join test_attachments attachment
+      on attachment.model_unique_id = model.unique_id
+    group by model.unique_id, model.model_type
+),
+coverage as (
+    select count(*) as total_models,
+           count(*) filter (where test_count > 0) as tested_models,
+           sum(test_count) as total_tests,
+           round(
+               count(*) filter (where test_count > 0 and model_type = 'staging')
+               * 100.0 / nullif(count(*) filter (where model_type = 'staging'), 0),
+               2
+           ) as staging_test_coverage_pct,
+           round(
+               count(*) filter (where test_count > 0 and model_type = 'intermediate')
+               * 100.0 / nullif(count(*) filter (where model_type = 'intermediate'), 0),
+               2
+           ) as intermediate_test_coverage_pct,
+           round(
+               count(*) filter (where test_count > 0 and model_type = 'marts')
+               * 100.0 / nullif(count(*) filter (where model_type = 'marts'), 0),
+               2
+           ) as marts_test_coverage_pct,
+           round(
+               count(*) filter (where test_count > 0 and model_type = 'other')
+               * 100.0 / nullif(count(*) filter (where model_type = 'other'), 0),
+               2
+           ) as other_test_coverage_pct
+    from model_tests
+)
+select total_models, total_tests, tested_models,
+       round(tested_models * 100.0 / nullif(total_models, 0), 2) as test_coverage_pct,
+       staging_test_coverage_pct,
+       intermediate_test_coverage_pct,
+       marts_test_coverage_pct,
+       other_test_coverage_pct,
+       round(total_tests * 1.0 / nullif(total_models, 0), 4) as test_to_model_ratio
+from coverage
+where tested_models * 100.0 / nullif(total_models, 0)
+      < {{ var('test_coverage_target', 100) }}

--- a/checks/fct_test_directories.sql
+++ b/checks/fct_test_directories.sql
@@ -1,0 +1,29 @@
+with tests as (
+    select t.unique_id, t.name, t.node_unique_id,
+           regexp_extract(
+               replace(t.properties_yml_file_path, chr(92), '/'),
+               '^(.*)/[^/]+$',
+               1
+           ) as test_directory
+    from {{ info_schema('data_tests') }} t
+    where {{ evaluator_check_in_scope('t') }}
+      and t.node_unique_id is not null
+      and t.test_name is not null
+),
+models as (
+    select m.unique_id, m.name,
+           regexp_extract(
+               replace(m.original_file_path, chr(92), '/'),
+               '^(.*)/[^/]+$',
+               1
+           ) as model_directory
+    from {{ info_schema('models') }} m
+    where {{ evaluator_check_in_scope('m') }}
+)
+select tests.unique_id, tests.name as test_name,
+       models.name as model_name,
+       tests.test_directory as current_test_directory,
+       models.model_directory as change_test_directory_to
+from tests
+join models on models.unique_id = tests.node_unique_id
+where tests.test_directory != models.model_directory

--- a/checks/fct_too_many_joins.sql
+++ b/checks/fct_too_many_joins.sql
@@ -1,0 +1,7 @@
+select e.child_unique_id as unique_id,
+       count(distinct e.parent_unique_id) as join_count
+from {{ info_schema('edges') }} e
+join {{ info_schema('models') }} m on m.unique_id = e.child_unique_id
+where {{ evaluator_check_in_scope('m') }}
+group by e.child_unique_id
+having count(distinct e.parent_unique_id) >= {{ var('too_many_joins_threshold', 7) }}

--- a/checks/fct_undocumented_models.sql
+++ b/checks/fct_undocumented_models.sql
@@ -1,0 +1,4 @@
+select unique_id, name, original_file_path
+from {{ info_schema('models') }} m
+where {{ evaluator_check_in_scope('m') }}
+  and nullif(trim(description), '') is null

--- a/checks/fct_undocumented_public_models.sql
+++ b/checks/fct_undocumented_public_models.sql
@@ -1,0 +1,22 @@
+with column_coverage as (
+    select node_unique_id,
+           count(*) as total_defined_columns,
+           count(*) filter (
+               where nullif(trim(description), '') is not null
+           ) as total_described_columns
+    from {{ info_schema('node_columns') }}
+    group by node_unique_id
+)
+select m.unique_id, m.name, m.access,
+       m.description,
+       coalesce(c.total_defined_columns, 0) as total_defined_columns,
+       coalesce(c.total_described_columns, 0) as total_described_columns
+from {{ info_schema('models') }} m
+left join column_coverage c on c.node_unique_id = m.unique_id
+where {{ evaluator_check_in_scope('m') }}
+  and m.access = 'public'
+  and (
+      nullif(trim(m.description), '') is null
+      or coalesce(c.total_defined_columns, 0) = 0
+      or c.total_described_columns < c.total_defined_columns
+  )

--- a/checks/fct_undocumented_source_tables.sql
+++ b/checks/fct_undocumented_source_tables.sql
@@ -1,0 +1,4 @@
+select unique_id, name, source_name, original_file_path
+from {{ info_schema('sources') }} s
+where {{ evaluator_check_in_scope('s') }}
+  and nullif(trim(description), '') is null

--- a/checks/fct_undocumented_sources.sql
+++ b/checks/fct_undocumented_sources.sql
@@ -1,0 +1,7 @@
+select source_name
+from {{ info_schema('sources') }} s
+where {{ evaluator_check_in_scope('s') }}
+group by source_name
+having count(*) filter (
+    where nullif(trim(source_description), '') is null
+) > 0

--- a/checks/fct_unused_sources.sql
+++ b/checks/fct_unused_sources.sql
@@ -1,0 +1,6 @@
+select s.unique_id, s.name, s.original_file_path
+from {{ info_schema('sources') }} s
+left join {{ info_schema('edges') }} e on e.parent_unique_id = s.unique_id
+where {{ evaluator_check_in_scope('s') }}
+group by s.unique_id, s.name, s.original_file_path
+having count(e.child_unique_id) = 0

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,6 +2,9 @@ name: 'dbt_project_evaluator'
 version: '1.0.0'
 config-version: 2
 
+info_schema:
+  version: 1
+
 require-dbt-version: [">=1.10.6", "<3.0.0"]
 
 model-paths: ["models"]
@@ -23,6 +26,10 @@ flags:
 dispatch:
   - macro_namespace: dbt
     search_order: ['dbt_project_evaluator', 'dbt']
+
+checks:
+  dbt_project_evaluator:
+    +severity: warn
 
 models:
   dbt_project_evaluator:

--- a/macros/native_checks.sql
+++ b/macros/native_checks.sql
@@ -1,0 +1,12 @@
+{% macro evaluator_check_in_scope(alias) -%}
+(
+    {{ alias }}.package_name != 'dbt_project_evaluator'
+    {% for package in var('exclude_packages', []) %}
+    and {{ alias }}.package_name != '{{ package }}'
+    {% endfor %}
+    {% for path in var('exclude_paths_from_project', []) %}
+    and coalesce({{ alias }}.original_file_path, '') not like '%{{ path }}%'
+    and {{ alias }}.unique_id not like '%{{ path | replace("/", "") }}%'
+    {% endfor %}
+)
+{%- endmacro %}


### PR DESCRIPTION
## Summary

- add native parse-time checks for 28 of dbt-project-evaluator's 29 rules
- query the versioned dbt information schema instead of materializing the evaluator DAG first
- preserve existing package/path exclusions and evaluator configuration variables
- default native findings to warning severity so ordinary `dbt build` remains advisory

## Coverage

The port covers DAG, documentation, testing, governance, structure, and performance rules, including recursive lineage rules, aggregate coverage metrics, source freshness, contracts/access, primary-key tests plus column constraints, and properties-directory parity.

The only deferred rule is `fct_hard_coded_references`, which requires parsed SQL or lint/static-analysis findings. Row-level exception seed handling is also documented as future work because parse-time checks do not execute warehouse seed relations.

## Dependency

This is a draft companion to dbt-labs/fs#13598. It requires the parse-time metadata plumbing from that stack before it can merge.

## Validation

- fresh `dbt check` run evaluated all 28 native checks with zero render/binder failures and fixture-matching violation counts
- coverage rows match the existing fixtures exactly: 18 models, 14 tests, 7 tested models, 38.89% coverage, and 0.7778 tests/model
- `PATH=<integration debug binary>:$PATH bash ./run_fusion_tests.sh duckdb` passed all three evaluator integration projects
- main fixture processed 84 models, 70 tests, 28 seeds, and 28 advisory checks successfully
