### PR TITLE
feat: publish v2 native project checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,28 @@ Currently, the following adapters are supported:
 
 ## Using This Package
 
+### Fusion native checks (v2)
+
+Version 2 includes native, parse-time project checks for 28 of the package's 29
+rules. Installing the package does not enable them automatically. Fusion users
+can disable the legacy warehouse models and opt into all native checks from the
+root project's `dbt_project.yml`:
+
+```yml
+models:
+  dbt_project_evaluator:
+    +enabled: false
+
+checks:
+  dbt_project_evaluator:
+    +enabled: true
+```
+
+The checks are advisory by default. Root-project configuration can enable one
+rule at a time or override `severity`; see [the native-check guide](checks/README.md)
+for package-wide and selective examples. The existing model-based implementation
+remains available for dbt Core projects.
+
 ### Cloning via dbt Package Hub
   
 Check [dbt Hub](https://hub.getdbt.com/dbt-labs/dbt_project_evaluator/latest/) for the latest installation instructions, or [read the docs](https://docs.getdbt.com/docs/package-management) for more information on installing packages.

--- a/checks/README.md
+++ b/checks/README.md
@@ -3,8 +3,54 @@
 These checks reproduce 28 of the 29 dbt-project-evaluator rules using
 parse-time dbt information-schema metadata. Each SQL file follows the native
 checks contract: zero rows pass; returned rows are violations.
-They default to `severity: warn`, matching the package's advisory behavior and
-allowing ordinary `dbt build` invocations to continue after reporting findings.
+Installed-package checks are disabled until the root project explicitly opts
+in. Once enabled, they default to `severity: warn`, matching the package's
+advisory behavior and allowing ordinary `dbt build` invocations to continue
+after reporting findings.
+
+## Opt in from a consuming project
+
+To replace the package's legacy warehouse models with every native check, add
+this to the consuming project's `dbt_project.yml`:
+
+```yaml
+models:
+  dbt_project_evaluator:
+    +enabled: false
+
+checks:
+  dbt_project_evaluator:
+    +enabled: true
+```
+
+Run the checks directly with `dbt check`. They also run as a precondition of
+`dbt build`; a check configured with `severity: error` blocks the build when it
+returns violations. `dbt run` does not execute native checks.
+
+To enable only selected rules, keep the package disabled and opt individual
+checks back in by name:
+
+```yaml
+models:
+  dbt_project_evaluator:
+    +enabled: false
+
+checks:
+  dbt_project_evaluator:
+    +enabled: false
+
+    fct_undocumented_models:
+      +enabled: true
+      +severity: error
+
+    fct_undocumented_source_tables:
+      +enabled: true
+      +severity: warn
+```
+
+Configuration in the consuming project takes precedence over the package's
+defaults. This lets teams start with advisory checks, promote selected rules to
+build-blocking errors, and leave the remaining rules disabled.
 
 ## Implemented
 

--- a/checks/_checks.yml
+++ b/checks/_checks.yml
@@ -1,0 +1,90 @@
+info_schema:
+  version: 1
+
+# Native checks are disabled by default when this package is installed. Once a root project opts
+# in, these package-local defaults make findings advisory unless the root project overrides them.
+checks:
+  - name: fct_chained_views_dependencies
+    config:
+      severity: warn
+  - name: fct_direct_join_to_source
+    config:
+      severity: warn
+  - name: fct_documentation_coverage
+    config:
+      severity: warn
+  - name: fct_duplicate_sources
+    config:
+      severity: warn
+  - name: fct_exposure_parents_materializations
+    config:
+      severity: warn
+  - name: fct_exposures_dependent_on_private_models
+    config:
+      severity: warn
+  - name: fct_marts_or_intermediate_dependent_on_source
+    config:
+      severity: warn
+  - name: fct_missing_primary_key_tests
+    config:
+      severity: warn
+  - name: fct_model_directories
+    config:
+      severity: warn
+  - name: fct_model_fanout
+    config:
+      severity: warn
+  - name: fct_model_naming_conventions
+    config:
+      severity: warn
+  - name: fct_multiple_sources_joined
+    config:
+      severity: warn
+  - name: fct_public_models_without_contract
+    config:
+      severity: warn
+  - name: fct_rejoining_of_upstream_concepts
+    config:
+      severity: warn
+  - name: fct_root_models
+    config:
+      severity: warn
+  - name: fct_source_directories
+    config:
+      severity: warn
+  - name: fct_source_fanout
+    config:
+      severity: warn
+  - name: fct_sources_without_freshness
+    config:
+      severity: warn
+  - name: fct_staging_dependent_on_marts_or_intermediate
+    config:
+      severity: warn
+  - name: fct_staging_dependent_on_staging
+    config:
+      severity: warn
+  - name: fct_test_coverage
+    config:
+      severity: warn
+  - name: fct_test_directories
+    config:
+      severity: warn
+  - name: fct_too_many_joins
+    config:
+      severity: warn
+  - name: fct_undocumented_models
+    config:
+      severity: warn
+  - name: fct_undocumented_public_models
+    config:
+      severity: warn
+  - name: fct_undocumented_source_tables
+    config:
+      severity: warn
+  - name: fct_undocumented_sources
+    config:
+      severity: warn
+  - name: fct_unused_sources
+    config:
+      severity: warn

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,9 +1,6 @@
 name: 'dbt_project_evaluator'
-version: '1.0.0'
+version: '2.0.0'
 config-version: 2
-
-info_schema:
-  version: 1
 
 require-dbt-version: [">=1.10.6", "<3.0.0"]
 
@@ -26,10 +23,6 @@ flags:
 dispatch:
   - macro_namespace: dbt
     search_order: ['dbt_project_evaluator', 'dbt']
-
-checks:
-  dbt_project_evaluator:
-    +severity: warn
 
 models:
   dbt_project_evaluator:

--- a/integration_tests_native_checks/README.md
+++ b/integration_tests_native_checks/README.md
@@ -1,0 +1,5 @@
+# Native-check package consumer
+
+This Fusion-only integration project installs dbt-project-evaluator as a local
+dependency and opts into its v2 native checks. It verifies the same root-project
+configuration that package users apply, including disabling the legacy models.

--- a/integration_tests_native_checks/dbt_project.yml
+++ b/integration_tests_native_checks/dbt_project.yml
@@ -1,0 +1,20 @@
+name: dbt_project_evaluator_native_checks
+version: 1.0.0
+config-version: 2
+profile: integration_tests
+
+model-paths: ["models"]
+
+models:
+  dbt_project_evaluator_native_checks:
+    +materialized: ephemeral
+  dbt_project_evaluator:
+    +enabled: false
+
+checks:
+  dbt_project_evaluator:
+    +enabled: true
+    +severity: warn
+
+flags:
+  send_anonymous_usage_stats: false

--- a/integration_tests_native_checks/models/staging/_sources.yml
+++ b/integration_tests_native_checks/models/staging/_sources.yml
@@ -1,0 +1,19 @@
+version: 2
+
+sources:
+  - name: raw_shop
+    description: Raw shop data.
+    schema: raw
+    tables:
+      - name: orders
+        description: Raw orders.
+
+models:
+  - name: stg_orders
+    description: Staged orders.
+    columns:
+      - name: order_id
+        description: Primary key.
+        data_tests:
+          - unique
+          - not_null

--- a/integration_tests_native_checks/models/staging/raw_shop/stg_orders.sql
+++ b/integration_tests_native_checks/models/staging/raw_shop/stg_orders.sql
@@ -1,0 +1,2 @@
+select 1 as order_id
+from {{ source('raw_shop', 'orders') }}

--- a/integration_tests_native_checks/packages.yml
+++ b/integration_tests_native_checks/packages.yml
@@ -1,0 +1,2 @@
+packages:
+  - local: ../

--- a/run_fusion_tests.sh
+++ b/run_fusion_tests.sh
@@ -8,13 +8,18 @@
 
 FUSION_VARS='{"deactivate_for_fusion": true}'
 
-echo "Running native-check package consumer tests"
-cd integration_tests_native_checks
-dbt deps --target $1 --profiles-dir ../integration_tests || exit 1
-dbt check --target $1 --profiles-dir ../integration_tests || exit 1
+if dbt check --help >/dev/null 2>&1; then
+    echo "Running native-check package consumer tests"
+    cd integration_tests_native_checks
+    dbt deps --target $1 --profiles-dir ../integration_tests || exit 1
+    dbt check --target $1 --profiles-dir ../integration_tests || exit 1
+    cd ..
+else
+    echo "Skipping native-check package consumer tests: installed Fusion has no dbt check command"
+fi
 
 echo "Running Fusion tests for the first project"
-cd ../integration_tests
+cd integration_tests
 dbt deps --target $1 || exit 1
 dbt build -x --target $1 --full-refresh --static-analysis=off --no-manage-state --vars "$FUSION_VARS" || exit 1
 

--- a/run_fusion_tests.sh
+++ b/run_fusion_tests.sh
@@ -8,8 +8,13 @@
 
 FUSION_VARS='{"deactivate_for_fusion": true}'
 
+echo "Running native-check package consumer tests"
+cd integration_tests_native_checks
+dbt deps --target $1 --profiles-dir ../integration_tests || exit 1
+dbt check --target $1 --profiles-dir ../integration_tests || exit 1
+
 echo "Running Fusion tests for the first project"
-cd integration_tests
+cd ../integration_tests
 dbt deps --target $1 || exit 1
 dbt build -x --target $1 --full-refresh --static-analysis=off --no-manage-state --vars "$FUSION_VARS" || exit 1
 


### PR DESCRIPTION
> [!NOTE]
> This is work-in-progress spike work to identify what is needed to make dbt-project-evaluator compatible with the dbt information schema and dbt checks. It is not yet a release-ready implementation.

## Summary

- explore publishing the native-check implementation as dbt-project-evaluator `2.0.0`
- keep the package `dbt_project.yml` valid in dbt Core by moving `info_schema` and check defaults to `checks/_checks.yml`
- leave installed native checks disabled until the consuming project opts in
- document package-wide and per-check configuration, including severity overrides
- retain the legacy warehouse models for dbt Core users
- add a Fusion-only consumer fixture that installs the package and runs all 28 supported native checks

## Consumer opt-in

```yaml
models:
  dbt_project_evaluator:
    +enabled: false

checks:
  dbt_project_evaluator:
    +enabled: true
```

Selective opt-in is also supported by setting the package to `+enabled: false` and enabling named checks beneath it.

## Coverage

This spike implements 28 of the 29 evaluator rules. `fct_hard_coded_references` remains deferred because it requires parsed SQL or lint/static-analysis findings rather than the parse-time information schema.

## Native PR stack

1. #593
2. #594 (this PR)

The stack also depends on dbt-labs/fs#13654, which is stacked on dbt-labs/fs#13598.

## Verification

- freshly rebuilt debug Fusion binary on the framework branch
- installed-package DuckDB smoke test: all 28 checks executed; 25 passed and 3 produced advisory warnings; command succeeded
- dbt Core 1.12.3 dependency load and parse succeeded with evaluator v2 installed
- `bash -n run_fusion_tests.sh`
- one metadata entry exists for each of the 28 check SQL files
