### PR TITLE
Fix Snowflake unicode-escape error from unescaped tojson in unpack macros

### DIFF
--- a/macros/unpack/get_exposure_values.sql
+++ b/macros/unpack/get_exposure_values.sql
@@ -24,7 +24,7 @@
               wrap_string_with_quotes(node.url),
               wrap_string_with_quotes(dbt.escape_single_quotes(node.owner.name)),
               wrap_string_with_quotes(dbt.escape_single_quotes(node.owner.email)),
-              wrap_string_with_quotes(node.meta | tojson)
+              wrap_string_with_quotes(dbt.escape_single_quotes(tojson(node.meta)))
             ]
           %}
 

--- a/macros/unpack/get_metric_values.sql
+++ b/macros/unpack/get_metric_values.sql
@@ -23,12 +23,12 @@
             wrap_string_with_quotes(dbt.escape_single_quotes(tojson(node.filter))),
             wrap_string_with_quotes(node.type_params.measure.name if node.type_params.measure else none),
             wrap_string_with_quotes(node.type_params.measure.alias if node.type_params.measure else none),
-            wrap_string_with_quotes(node.type_params.numerator | tojson),
-            wrap_string_with_quotes(node.type_params.denominator | tojson),
+            wrap_string_with_quotes(dbt.escape_single_quotes(tojson(node.type_params.numerator))),
+            wrap_string_with_quotes(dbt.escape_single_quotes(tojson(node.type_params.denominator))),
             wrap_string_with_quotes(dbt.escape_single_quotes(node.type_params.expr)),
-            wrap_string_with_quotes(((node.type_params.cumulative_type_params.window if node.type_params.cumulative_type_params else none) or node.type_params.window) | tojson),
+            wrap_string_with_quotes(dbt.escape_single_quotes(tojson(((node.type_params.cumulative_type_params.window if node.type_params.cumulative_type_params else none) or node.type_params.window)))),
             wrap_string_with_quotes((node.type_params.cumulative_type_params.grain_to_date or node.type_params.grain_to_date) if node.type_params.cumulative_type_params else node.type_params.grain_to_date),
-            wrap_string_with_quotes(node.meta | tojson)
+            wrap_string_with_quotes(dbt.escape_single_quotes(tojson(node.meta)))
             ]
           %}
 

--- a/macros/unpack/get_node_values.sql
+++ b/macros/unpack/get_node_values.sql
@@ -40,11 +40,11 @@
                 wrap_string_with_quotes(node.alias),
                 "cast(" ~ dbt_project_evaluator.is_not_empty_string(node.description) | trim ~ " as " ~ dbt.type_boolean() ~ ")",
                 "''" if not node.column_name else wrap_string_with_quotes(dbt.escape_single_quotes(node.column_name)),
-                wrap_string_with_quotes(node.meta | tojson),
+                wrap_string_with_quotes(dbt.escape_single_quotes(tojson(node.meta))),
                 wrap_string_with_quotes(dbt.escape_single_quotes(hard_coded_references)),
                 number_lines,
                 sql_complexity,
-                wrap_string_with_quotes(node.get('depends_on',{}).get('macros',[]) | tojson),
+                wrap_string_with_quotes(dbt.escape_single_quotes(tojson(node.get('depends_on',{}).get('macros',[])))),
                 "cast(" ~ dbt_project_evaluator.is_not_empty_string(node.test_metadata) | trim ~ " as " ~ dbt.type_boolean() ~ ")",
                 "cast(" ~ dbt_project_evaluator.bool_literal(exclude_node) | trim ~ " as " ~ dbt.type_boolean() ~ ")",
             ]

--- a/macros/unpack/get_source_values.sql
+++ b/macros/unpack/get_source_values.sql
@@ -37,7 +37,7 @@
               wrap_string_with_quotes(node.package_name),
               wrap_string_with_quotes(node.loader),
               wrap_string_with_quotes(node.identifier),
-              wrap_string_with_quotes(node.meta | tojson),
+              wrap_string_with_quotes(dbt.escape_single_quotes(tojson(node.meta))),
               "cast(" ~ dbt_project_evaluator.bool_literal(exclude_source) | trim ~ " as " ~ dbt.type_boolean() ~ ")",
             ]
         %}


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes

## Link to Issue
Closes #597

## Description & motivation

`node.meta` (and a few metric `type_params` fields) get wrapped in quotes via `wrap_string_with_quotes(X | tojson)`. Jinja's `tojson` filter is HTML-safe and turns `'` into `'`, but `wrap_string_with_quotes` does no SQL escaping on top, so the literal `'` lands in the compiled SQL. On Snowflake, any value with an apostrophe next to a hex-like character overflows the `\uXXXX` literal parser and fails compilation, taking down `stg_nodes`/`stg_sources`/`stg_metrics`/`stg_exposures` and everything downstream.

`metric.filter` already hit this (#439) and was fixed with `escape_single_quotes(tojson(...))`. This PR applies that same fix to the remaining fields that still use the old `X | tojson` pattern:

- `get_node_values.sql`: `node.meta`, `node.depends_on.macros`
- `get_source_values.sql`: `node.meta`
- `get_metric_values.sql`: `node.meta`, `type_params.numerator`, `type_params.denominator`, cumulative/rolling window
- `get_exposure_values.sql`: `node.meta`

No behavior changes for values that don't contain an apostrophe.

## Integration Test Screenshot

I don't have your multi-warehouse `integration_tests` harness set up, so no screenshot from that suite. I verified against a real ~4,200-model Snowflake project instead: built `stg_nodes`, `stg_sources`, `stg_metrics`, and `stg_exposures` against real `meta` values that reproduce this bug (e.g. `meta: {source_system: "'C2C'"}`) — failed before this change with the reported unicode-escape error, succeeded after.

## Checklist
- [ ] BigQuery
- [ ] Postgres
- [ ] Redshift
- [x] Snowflake
- [ ] Databricks
- [ ] DuckDB
- [ ] Trino/Starburst
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
